### PR TITLE
Fix asynchronous fb read

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/radius/utils/FirebaseUtilityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/utils/FirebaseUtilityTest.java
@@ -123,10 +123,7 @@ public class FirebaseUtilityTest extends AndroidTestCase {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-
-
-
-
+        
     }
 
     @Test

--- a/app/src/androidTest/java/ch/epfl/sweng/radius/utils/FirebaseUtilityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/utils/FirebaseUtilityTest.java
@@ -1,0 +1,147 @@
+package ch.epfl.sweng.radius.utils;
+
+import android.support.annotation.NonNull;
+import android.test.AndroidTestCase;
+import android.util.Log;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.Logger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import ch.epfl.sweng.radius.database.ChatLogs;
+import ch.epfl.sweng.radius.database.Message;
+import ch.epfl.sweng.radius.database.User;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.*;
+
+public class FirebaseUtilityTest extends AndroidTestCase {
+    private static final String TAG = "Firebase";
+
+
+//    private static Logger logger = Logger.getLogger(FirebaseUtilityTest.class);
+
+    private CountDownLatch authSignal = null;
+    private FirebaseAuth auth;
+
+    private User user;
+    private Message msg;
+    private ChatLogs logs;
+
+    private FirebaseUtility user_fbutil;
+  //  private FirebaseUtility logs_fbutil;
+  //  private FirebaseUtility msg_fbutil;
+
+
+    @Override
+    public void setUp() throws InterruptedException {
+        authSignal = new CountDownLatch(1);
+
+        user = new User("usertTest00");
+
+        user_fbutil = new FirebaseUtility(user);
+
+       // logs_fbutil = new FirebaseUtility(logs);
+       // msg_fbutil = new FirebaseUtility(msg);
+
+
+        auth = FirebaseAuth.getInstance();
+        if(auth.getCurrentUser() == null) {
+            auth.signInWithEmailAndPassword("urbi@orbi.it", "12345678").addOnCompleteListener(
+                    new OnCompleteListener<AuthResult>() {
+
+                        @Override
+                        public void onComplete(@NonNull final Task<AuthResult> task) {
+
+                            final AuthResult result = task.getResult();
+                            final FirebaseUser user = result.getUser();
+                            authSignal.countDown();
+                        }
+                    });
+        } else {
+            authSignal.countDown();
+        }
+        authSignal.await(100, TimeUnit.SECONDS);
+
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if(auth != null) {
+            auth.signOut();
+            auth = null;
+        }
+    }
+
+    @Test
+    public void isNew() {
+
+    }
+
+    @Test
+    public void testListenUser() throws InterruptedException {
+
+        user_fbutil.listenUser();
+        
+        // Waiting before implementation of synchronization
+        sleep(2000);
+
+        user = user_fbutil.getUser();
+        Log.e(TAG, user.getStatus());
+
+        if ((!"Being tested on".equals(user.getStatus()))) throw new AssertionError();
+
+    }
+
+    @Test
+    public void testWriteUser() {
+    }
+
+    @Test
+    public void testWriteUser1() {
+    }
+
+    @Test
+    public void listenMessage() {
+    }
+
+    @Test
+    public void writeMessage() {
+    }
+
+    @Test
+    public void writeMessage1() {
+    }
+
+    @Test
+    public void listenChatLogs() {
+    }
+
+    @Test
+    public void writeChatLogs() {
+    }
+
+    @Test
+    public void writeChatLogs1() {
+    }
+
+    @Test
+    public void getUser() {
+    }
+
+    @Test
+    public void setUser() {
+    }
+}

--- a/app/src/androidTest/java/ch/epfl/sweng/radius/utils/FirebaseUtilityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/utils/FirebaseUtilityTest.java
@@ -13,6 +13,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.Logger;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -94,9 +95,6 @@ public class FirebaseUtilityTest extends AndroidTestCase {
     public void testListenUser() throws InterruptedException {
 
         user_fbutil.listenUser();
-        
-        // Waiting before implementation of synchronization
-        sleep(2000);
 
         user = user_fbutil.getUser();
         Log.e(TAG, user.getStatus());
@@ -107,6 +105,28 @@ public class FirebaseUtilityTest extends AndroidTestCase {
 
     @Test
     public void testWriteUser() {
+
+        User new_user = new User("testUser01");
+
+        new_user.setStatus("Testing writing other user to DB");
+        try {
+            user_fbutil.writeUser(new_user);
+
+            /* Fetch result if exists */
+            user_fbutil.setUser(new_user);
+            user_fbutil.listenUser();
+
+            new_user = user_fbutil.getUser();
+
+            if((!"Testing writing other user to DB".equals(new_user.getStatus()))) throw new AssertionError();
+
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+
+
+
     }
 
     @Test

--- a/app/src/main/java/ch/epfl/sweng/radius/MainActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/MainActivity.java
@@ -62,13 +62,10 @@ public class MainActivity extends AppCompatActivity {
                     User currentUser = new User(myAuth.getCurrentUser().getUid());
                     FirebaseUtility firebase = new FirebaseUtility(currentUser);
                     
-                    if(firebase.isNew()){
-                        try {
-                            firebase.writeUser();
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                    } else {
+                    if(firebase.isNew()) {
+                        firebase.writeUser();
+                    }
+                    else {
                         try {
                             firebase.listenUser();
                         } catch (InterruptedException e) {

--- a/app/src/main/java/ch/epfl/sweng/radius/MainActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/MainActivity.java
@@ -63,9 +63,17 @@ public class MainActivity extends AppCompatActivity {
                     FirebaseUtility firebase = new FirebaseUtility(currentUser);
                     
                     if(firebase.isNew()){
-                        firebase.writeUser();
+                        try {
+                            firebase.writeUser();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
                     } else {
-                        firebase.listenUser();
+                        try {
+                            firebase.listenUser();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
                     }
 
                     startActivity(new Intent(MainActivity.this, AccountActivity.class));

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/FirebaseUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/FirebaseUtility.java
@@ -119,21 +119,19 @@ public class FirebaseUtility {
             @Override
             public void  onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 user = dataSnapshot.getValue(User.class);
-
-                Log.e("Firebase", "User data has been read.");
-
+                Log.w("Firebase", "User data has been read.");
+                Log.w("Firebase", getUser().getStatus());
             }
 
             @Override
             public void onCancelled(@NonNull DatabaseError databaseError) {
-                Log.e("Firebase", "Failed to read user", databaseError.toException());
+                Log.w("Firebase", "Failed to read user", databaseError.toException());
 
             }
         };
 
         database.child(user.getUserID()).addListenerForSingleValueEvent(listener);
     }
-
 
     public void writeUser(){
 
@@ -236,6 +234,7 @@ public class FirebaseUtility {
     }
 
     public User getUser() {
+
         return user;
     }
 

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/FirebaseUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/FirebaseUtility.java
@@ -20,6 +20,8 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.ValueEventListener;
 
+import java.util.concurrent.Semaphore;
+
 import ch.epfl.sweng.radius.database.ChatLogs;
 import ch.epfl.sweng.radius.database.Message;
 import ch.epfl.sweng.radius.database.User;
@@ -34,6 +36,7 @@ public class FirebaseUtility {
     private User        user;
     private Message     msg;
     private ChatLogs    chatLogs;
+    private Semaphore   semaphore;
 
     /**
      *
@@ -45,6 +48,7 @@ public class FirebaseUtility {
         initDB();
         this.user      = user;
         this.database  = fireDB.getReference("users");
+
     }
 
     /**
@@ -70,11 +74,13 @@ public class FirebaseUtility {
         initDB();
         this.chatLogs    = dataType;
         this.database    = fireDB.getReference("chatlogs");
+
     }
 
     private void initDB(){
         this.auth       = FirebaseAuth.getInstance();
         this.fireDB     = FirebaseDatabase.getInstance();
+        this.semaphore = new Semaphore(0);
     }
     // TODO : #Salezer, must be fixed
 
@@ -111,16 +117,17 @@ public class FirebaseUtility {
 
 
 
-    public void listenUser(){
+    public void listenUser() throws InterruptedException {
 
         ValueEventListener  listener;
 
-        listener = new ValueEventListener() {
+        database.child(user.getUserID()).addListenerForSingleValueEvent( new ValueEventListener() {
             @Override
             public void  onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 user = dataSnapshot.getValue(User.class);
                 Log.w("Firebase", "User data has been read.");
                 Log.w("Firebase", getUser().getStatus());
+                semaphore.release();
             }
 
             @Override
@@ -128,28 +135,32 @@ public class FirebaseUtility {
                 Log.w("Firebase", "Failed to read user", databaseError.toException());
 
             }
-        };
+        });
+        semaphore.acquire();
 
-        database.child(user.getUserID()).addListenerForSingleValueEvent(listener);
     }
 
-    public void writeUser(){
+    public void writeUser() throws InterruptedException {
 
+        semaphore.acquire();
         database.child(user.getUserID()).setValue(user);
+        semaphore.release();
 
         return;
 
     }
 
-    public void writeUser(User new_user){
+    public void writeUser(User new_user) throws InterruptedException {
 
+        semaphore.acquire();
         database.child(new_user.getUserID()).setValue(new_user);
+        semaphore.release();
 
         return;
 
     }
 
-    public void listenMessage(){
+    public void listenMessage() throws InterruptedException {
 
         ValueEventListener  listener;
 
@@ -157,6 +168,7 @@ public class FirebaseUtility {
             @Override
             public void  onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 msg = dataSnapshot.getValue(Message.class);
+                semaphore.release();
 
                 Log.e("Firebase", "Message data has been read.");
 
@@ -170,28 +182,32 @@ public class FirebaseUtility {
         };
 
         database.child(Long.toString(msg.getMessageID())).addListenerForSingleValueEvent(listener);
-
+        semaphore.acquire();
         return;
 
     }
 
-    public void writeMessage(){
+    public void writeMessage() throws InterruptedException {
 
+        semaphore.acquire();
         database.child(Long.toString(msg.getMessageID())).setValue(msg);
+        semaphore.release();
 
         return;
 
     }
 
-    public void writeMessage(Message new_msg){
+    public void writeMessage(Message new_msg) throws InterruptedException {
 
+        semaphore.acquire();
         database.child(Long.toString(new_msg.getMessageID())).setValue(new_msg);
+        semaphore.release();
 
         return;
 
     }
 
-    public void listenChatLogs(){
+    public void listenChatLogs() throws InterruptedException {
 
         ValueEventListener  listener;
 
@@ -199,7 +215,7 @@ public class FirebaseUtility {
             @Override
             public void  onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 chatLogs = dataSnapshot.getValue(ChatLogs.class);
-
+                semaphore.release();
                 Log.e("Firebase", "Chatlogs data has been read.");
 
             }
@@ -212,23 +228,25 @@ public class FirebaseUtility {
         };
         // TODO Fix ID For Chatlogs
         database.child(chatLogs.getParticipants().get(0).getUserID()).addListenerForSingleValueEvent(listener);
-
+        semaphore.acquire();
         return;
 
     }
 
-    public void writeChatLogs(){
+    public void writeChatLogs() throws InterruptedException {
 
+        semaphore.acquire();
         database.child(Long.toString(msg.getMessageID())).setValue(msg);
-
+        semaphore.release();
         return;
 
     }
 
-    public void writeChatLogs(ChatLogs new_chatlogs){
+    public void writeChatLogs(ChatLogs new_chatlogs) throws InterruptedException {
+        semaphore.acquire();
         database.child(new_chatlogs.getParticipants().get(0).getUserID())
                 .setValue(new_chatlogs);
-
+        semaphore.release();
         return;
 
     }

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/FirebaseUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/FirebaseUtility.java
@@ -140,21 +140,17 @@ public class FirebaseUtility {
 
     }
 
-    public void writeUser() throws InterruptedException {
+    public void writeUser(){
 
-        semaphore.acquire();
         database.child(user.getUserID()).setValue(user);
-        semaphore.release();
 
         return;
 
     }
 
-    public void writeUser(User new_user) throws InterruptedException {
+    public void writeUser(User new_user) {
 
-        semaphore.acquire();
         database.child(new_user.getUserID()).setValue(new_user);
-        semaphore.release();
 
         return;
 
@@ -187,21 +183,17 @@ public class FirebaseUtility {
 
     }
 
-    public void writeMessage() throws InterruptedException {
+    public void writeMessage() {
 
-        semaphore.acquire();
         database.child(Long.toString(msg.getMessageID())).setValue(msg);
-        semaphore.release();
 
         return;
 
     }
 
-    public void writeMessage(Message new_msg) throws InterruptedException {
+    public void writeMessage(Message new_msg) {
 
-        semaphore.acquire();
         database.child(Long.toString(new_msg.getMessageID())).setValue(new_msg);
-        semaphore.release();
 
         return;
 
@@ -233,20 +225,16 @@ public class FirebaseUtility {
 
     }
 
-    public void writeChatLogs() throws InterruptedException {
+    public void writeChatLogs()  {
 
-        semaphore.acquire();
         database.child(Long.toString(msg.getMessageID())).setValue(msg);
-        semaphore.release();
         return;
 
     }
 
-    public void writeChatLogs(ChatLogs new_chatlogs) throws InterruptedException {
-        semaphore.acquire();
+    public void writeChatLogs(ChatLogs new_chatlogs) {
         database.child(new_chatlogs.getParticipants().get(0).getUserID())
                 .setValue(new_chatlogs);
-        semaphore.release();
         return;
 
     }


### PR DESCRIPTION
Modified the FireBaseUtility to use semaphore in IO access to Firebase, hence enforcing synchronous operations.
Modified MainActivity because of semaphore related Exception handling was then necessary