### PR TITLE
Fb notification when message received - DO NOT MERGE

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:customtabs:28.0.0'
     implementation 'com.android.support:design:28.0.0'
+    implementation "com.android.support:support-compat:28.0.0"
 
     //Picasso for downloading images from url
     implementation 'com.squareup.picasso:picasso:2.71828'

--- a/app/src/androidTest/java/ch/epfl/sweng/radius/messages/MessageListActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/messages/MessageListActivityTest.java
@@ -168,9 +168,9 @@ public class MessageListActivityTest extends ActivityInstrumentationTestCase2<Me
         assertEquals("You can't text this user.", ((EditText) mlActivity.findViewById(R.id.edittext_chatbox)).getText().toString());
     }
 
-    @Ignore
     @Test
     public void sendMessage() {
+        mlActivity.showNotification("Coucou", "Coucou");
     }
 
     @Ignore

--- a/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
@@ -70,28 +70,19 @@ public class AccountActivity extends AppCompatActivity {
     }
     private myTimer timerTask;
 
-    @SuppressLint("NewApi")
     private void initChannel(String channel_name, String channel_description) {
         NotificationManager mNotificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
-        String id = channel_name;
-        CharSequence name = channel_name;
-        String description = channel_description;
-        int importance = NotificationManager.IMPORTANCE_HIGH;
-
         NotificationChannel mChannel = null;
-    //    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            mChannel = new NotificationChannel(id, name, importance);
-
-            mChannel.setDescription(description);
-            mChannel.enableLights(true);
-            mChannel.setLightColor(Color.RED);
-            mChannel.enableVibration(true);
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            mChannel = new NotificationChannel(channel_name, channel_name, NotificationManager.IMPORTANCE_HIGH);
+            mChannel.setDescription(channel_description); mChannel.enableLights(true);
+            mChannel.setLightColor(Color.RED);mChannel.enableVibration(true);
             mChannel.setVibrationPattern(new long[]{100, 200, 300, 400, 500, 400, 300, 200, 400});
 
             mNotificationManager.createNotificationChannel(mChannel);
-      //  }
+        }
 
         NotificationCompat.Builder msgNotif = new NotificationCompat.Builder(this, "radiusNotif");
         NotificationCompat.Builder reqNotif = new NotificationCompat.Builder(this, "radiusNotif");

--- a/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
@@ -1,5 +1,6 @@
 package ch.epfl.sweng.radius;
 
+import android.annotation.SuppressLint;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -69,6 +70,7 @@ public class AccountActivity extends AppCompatActivity {
     }
     private myTimer timerTask;
 
+    @SuppressLint("NewApi")
     private void initChannel(String channel_name, String channel_description) {
         NotificationManager mNotificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
@@ -79,7 +81,7 @@ public class AccountActivity extends AppCompatActivity {
         int importance = NotificationManager.IMPORTANCE_HIGH;
 
         NotificationChannel mChannel = null;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+    //    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             mChannel = new NotificationChannel(id, name, importance);
 
             mChannel.setDescription(description);
@@ -89,7 +91,7 @@ public class AccountActivity extends AppCompatActivity {
             mChannel.setVibrationPattern(new long[]{100, 200, 300, 400, 500, 400, 300, 200, 400});
 
             mNotificationManager.createNotificationChannel(mChannel);
-        }
+      //  }
 
         NotificationCompat.Builder msgNotif = new NotificationCompat.Builder(this, "radiusNotif");
         NotificationCompat.Builder reqNotif = new NotificationCompat.Builder(this, "radiusNotif");

--- a/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
@@ -70,12 +70,13 @@ public class AccountActivity extends AppCompatActivity {
     }
     private myTimer timerTask;
 
-    private void initChannel(String channel_name, String channel_description) {
+    public void initChannel(String channel_name, String channel_description) {
         NotificationManager mNotificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
         NotificationChannel mChannel = null;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            System.out.print("HEELLLO");
             mChannel = new NotificationChannel(channel_name, channel_name, NotificationManager.IMPORTANCE_HIGH);
             mChannel.setDescription(channel_description); mChannel.enableLights(true);
             mChannel.setLightColor(Color.RED);mChannel.enableVibration(true);

--- a/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
@@ -1,12 +1,19 @@
 package ch.epfl.sweng.radius;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 import android.support.design.widget.BottomNavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.app.NotificationCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -23,6 +30,7 @@ import ch.epfl.sweng.radius.friends.FriendsFragment;
 import ch.epfl.sweng.radius.home.HomeFragment;
 import ch.epfl.sweng.radius.messages.MessagesFragment;
 import ch.epfl.sweng.radius.profile.ProfileFragment;
+import ch.epfl.sweng.radius.utils.NotificationUtility;
 
 public class AccountActivity extends AppCompatActivity {
 
@@ -61,7 +69,33 @@ public class AccountActivity extends AppCompatActivity {
     }
     private myTimer timerTask;
 
+    private void initChannel(String channel_name, String channel_description) {
+        NotificationManager mNotificationManager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
+        String id = channel_name;
+        CharSequence name = channel_name;
+        String description = channel_description;
+        int importance = NotificationManager.IMPORTANCE_HIGH;
+
+        NotificationChannel mChannel = null;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            mChannel = new NotificationChannel(id, name, importance);
+
+            mChannel.setDescription(description);
+            mChannel.enableLights(true);
+            mChannel.setLightColor(Color.RED);
+            mChannel.enableVibration(true);
+            mChannel.setVibrationPattern(new long[]{100, 200, 300, 400, 500, 400, 300, 200, 400});
+
+            mNotificationManager.createNotificationChannel(mChannel);
+        }
+
+        NotificationCompat.Builder msgNotif = new NotificationCompat.Builder(this, "radiusNotif");
+        NotificationCompat.Builder reqNotif = new NotificationCompat.Builder(this, "radiusNotif");
+
+        NotificationUtility.getInstance(mNotificationManager, msgNotif, reqNotif);
+    }
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -78,7 +112,7 @@ public class AccountActivity extends AppCompatActivity {
         friendsFragment = new FriendsFragment();
         profileFragment = new ProfileFragment();
 
-
+        initChannel("radiusNotif", "radius notifications");
         loadFragment(homeFragment);
 
         BottomNavigationView bottomNavigationView = findViewById(R.id.navigationView);

--- a/app/src/main/java/ch/epfl/sweng/radius/database/FirebaseUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/FirebaseUtility.java
@@ -35,6 +35,7 @@ class ChildListener implements ChildEventListener {
 
     @Override
     public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+        Log.e("Notification", "CHild added !");
         callback.onFinish(dataSnapshot.getValue(child.second));
     }
 

--- a/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
@@ -1,9 +1,6 @@
 package ch.epfl.sweng.radius.database;
 
-import com.google.android.gms.maps.model.LatLng;
-
 import java.io.Serializable;
-import java.util.UUID;
 
 public class MLocation implements DatabaseObject, Serializable {
 

--- a/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
@@ -23,7 +23,7 @@ public class MLocation implements DatabaseObject, Serializable {
     private String interests;
 
     public MLocation(){
-        this.userID = UUID.randomUUID().toString().substring(0, 20);
+        this.userID = Database.getInstance().getCurrent_user_id();
         this.latitude = 46.5160698;
         this.longitude = 6.5681216000000004;
         this.title = "";

--- a/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
@@ -3,6 +3,7 @@ package ch.epfl.sweng.radius.database;
 import com.google.android.gms.maps.model.LatLng;
 
 import java.io.Serializable;
+import java.util.UUID;
 
 public class MLocation implements DatabaseObject, Serializable {
 
@@ -20,6 +21,20 @@ public class MLocation implements DatabaseObject, Serializable {
     private double radius; // Use it only if the mLocation is a group.
     private String spokenLanguages;
     private String interests;
+
+    public MLocation(){
+        this.userID = UUID.randomUUID().toString().substring(0, 20);
+        this.latitude = 46.5160698;
+        this.longitude = 6.5681216000000004;
+        this.title = "";
+        this.message = "";
+        this.locationType = 0;
+        this.radius = 5000;
+        this.isVisible = true;
+        this.urlProfilePhoto = "https://firebasestorage.googleapis.com/v0/b/radius-1538126456577.appspot.com/o/profilePictures%2Fdefault.png?alt=media&token=ccd39de0-9921-487b-90e7-3501262d7835";
+        this.spokenLanguages = "";
+        this.interests = "";
+    }
 
     public MLocation(String userID){
         this.userID = userID;

--- a/app/src/main/java/ch/epfl/sweng/radius/database/OthersInfo.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/OthersInfo.java
@@ -128,6 +128,8 @@ public class OthersInfo extends DBObservable{
     public void putInTable(MLocation loc){
         switch (loc.getLocationType()){
             case 0:
+                if(loc.getID().equals(UserInfo.getInstance().getCurrentPosition().getID()))
+                    break;
                 usersPos.put(loc.getID(), loc);
                 break;
             case 1:

--- a/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
@@ -181,7 +181,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
             }
     }
 
-    private void initMap() {
+    public void initMap() {
 
         if (mapListener.getCurrCoordinates() != null) {
 

--- a/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
@@ -191,6 +191,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
             moveCamera(coord, ZOOM);
             // Push current location to DB
             // Write the location of the current user to the database
+            /*
             Database.getInstance().readObjOnce(new MLocation("EPFL"), Database.Tables.LOCATIONS, new CallBackDatabase() {
                 @Override
                 public void onFinish(Object value) {
@@ -204,7 +205,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
                 public void onError(DatabaseError error) {
 
                 }
-            });
+            });*/
           //  mapListener.setMyPos(myPos);
 
             // Do locations here

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/ChatState.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/ChatState.java
@@ -19,7 +19,8 @@ public class ChatState{
     }
 
     public void msgReceived(){
-        unreadMsg++;
+
+        if(!isRunning)unreadMsg++;
     }
 
     public boolean isRunning(){

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/ChatState.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/ChatState.java
@@ -1,0 +1,4 @@
+package ch.epfl.sweng.radius.messages;
+
+class ChatState {
+}

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/ChatState.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/ChatState.java
@@ -1,4 +1,32 @@
 package ch.epfl.sweng.radius.messages;
 
-class ChatState {
+public class ChatState{
+    private boolean isRunning;
+    private int     unreadMsg;
+
+    public ChatState(){
+        this.isRunning = true;
+        this.unreadMsg = 0;
+    }
+
+    public void clear(){
+        isRunning = true;
+        unreadMsg = 0;
+    }
+
+    public void leaveActivity(){
+        isRunning = false;
+    }
+
+    public void msgReceived(){
+        unreadMsg++;
+    }
+
+    public boolean isRunning(){
+        return isRunning;
+    }
+
+    public int getUnreadMsg() {
+        return unreadMsg;
+    }
 }

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
@@ -337,9 +337,7 @@ public class MessageListActivity extends AppCompatActivity {
     @Override
     public void onPause(){
         super.onPause();
-        if(isChatRunning.containsKey(chatId)){
-            isChatRunning.get(chatId).leaveActivity();
-        }
+        if(isChatRunning.containsKey(chatId))isChatRunning.get(chatId).leaveActivity();
     }
 
     @Override
@@ -353,12 +351,7 @@ public class MessageListActivity extends AppCompatActivity {
         setContentView(R.layout.activity_message_list);
         messageZone = findViewById(R.id.edittext_chatbox);
 
-        setInfo();
-
-        setUpUI();
-        setUpSendButton();
-        setUpListener();
-        setEnabled(true);
+        setInfo();setUpUI();setUpSendButton();setUpListener();setEnabled(true);
     }
 
     @Override

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
@@ -1,8 +1,13 @@
 package ch.epfl.sweng.radius.messages;
 
+import android.app.Notification;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Bundle;
+import android.support.v4.app.NotificationCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -28,6 +33,9 @@ import ch.epfl.sweng.radius.database.Message;
 import ch.epfl.sweng.radius.database.OthersInfo;
 import ch.epfl.sweng.radius.database.User;
 import ch.epfl.sweng.radius.database.UserInfo;
+import ch.epfl.sweng.radius.utils.NotificationUtility;
+
+import static java.security.AccessController.getContext;
 
 
 /**
@@ -42,7 +50,6 @@ public class MessageListActivity extends AppCompatActivity {
     private ChatLogs chatLogs;
     private String chatId, otherUserId, myID;
     private ValueEventListener listener;
-
     //these might cause problems when we switch to multiple users and multiple different chats
     //This field will be used to enable chat with FRIENDS not in radius
     private static User myUser, otherUser;
@@ -61,6 +68,14 @@ public class MessageListActivity extends AppCompatActivity {
 
         }
     };
+
+    public void showNotification() {
+        Log.e("Notification", " Showed");
+        PendingIntent pi = PendingIntent.getActivity(this, 0, new Intent(this, MessageListActivity.class), 0);
+        Resources r = getResources();
+        NotificationUtility.getInstance(null, null, null).notifyNewMessage(chatId, "Coucou", pi);
+    }
+
 
     private String getOtherID() {
         String otherId = this.otherUserId;
@@ -311,6 +326,8 @@ public class MessageListActivity extends AppCompatActivity {
         setUpSendButton();
         setUpListener();
         setEnabled(true);
+        showNotification();
+
     }
 
     @Override

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
@@ -174,7 +174,7 @@ public class MessageListActivity extends AppCompatActivity {
 
             isChatRunning.get(chatId).msgReceived();
 
-            showNotification(message.getContentMessage().substring(0, min(20, message.getContentMessage().length())), senderNickname);
+            showNotification(message.getContentMessage(), senderNickname);
         }
     }
 

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
@@ -32,43 +32,11 @@ import ch.epfl.sweng.radius.utils.NotificationUtility;
 
 import static java.lang.Math.min;
 
-
 /**
  * Activity that hosts messages between two users
  * MessageListActivity and MessageListAdapter and some layout files are inspired from https://blog.sendbird.com/android-chat-tutorial-building-a-messaging-ui
  */
 public class MessageListActivity extends AppCompatActivity {
-
-    class chatState{
-        private boolean isRunning;
-        private int     unreadMsg;
-
-        public chatState(){
-            this.isRunning = true;
-            this.unreadMsg = 0;
-        }
-
-        public void clear(){
-            isRunning = true;
-            unreadMsg = 0;
-        }
-
-        public void leaveActivity(){
-            isRunning = false;
-        }
-
-        public void msgReceived(){
-            unreadMsg++;
-        }
-
-        public boolean isRunning(){
-            return isRunning;
-        }
-
-        public int getUnreadMsg() {
-            return unreadMsg;
-        }
-    }
 
     private RecyclerView myMessageRecycler;
     private MessageListAdapter myMessageAdapter;
@@ -80,7 +48,7 @@ public class MessageListActivity extends AppCompatActivity {
     //This field will be used to enable chat with FRIENDS not in radius
     private MLocation otherLoc;
     private Database database;
-    private static HashMap<String, chatState> isChatRunning = new HashMap<>();
+    private static HashMap<String, ChatState> isChatRunning = new HashMap<>();
 
     private final CallBackDatabase otherLocationCallback = new CallBackDatabase() {
         @Override
@@ -98,13 +66,10 @@ public class MessageListActivity extends AppCompatActivity {
     public void showNotification(String content, String senderId) {
         // Setup Intent to end here in case of click
         Intent notifIntent = new Intent(this, MessageListActivity.class);
-        notifIntent.putExtra("chatId", this.chatId);
-        notifIntent.putExtra("otherId", this.otherUserId);
+        notifIntent.putExtra("chatId", this.chatId).putExtra("otherId", this.otherUserId);
 
-        PendingIntent pi = PendingIntent.getActivity(this, 0,notifIntent
-                , 0);
+        PendingIntent pi = PendingIntent.getActivity(this, 0,notifIntent, 0);
         // Build and show notification
-        // TODO: Change unique Notification by list or remove ID
         NotificationUtility.getInstance(null, null, null)
                 .notifyNewMessage(senderId, content, pi);
     }
@@ -113,10 +78,8 @@ public class MessageListActivity extends AppCompatActivity {
     private String getOtherID() {
         String otherId = this.otherUserId;
         if (chatLogs.getMembersId().size() == 2) {
-            String tempID = chatLogs.getMembersId().get(0);
-            String tempID2 = chatLogs.getMembersId().get(1);
-            otherId = tempID.equals(myID) ?
-                    tempID : tempID2;
+            String tempID = chatLogs.getMembersId().get(0), tempID2 = chatLogs.getMembersId().get(1);
+            otherId = tempID.equals(myID) ? tempID : tempID2;
         }
         return otherId;
     }
@@ -126,8 +89,7 @@ public class MessageListActivity extends AppCompatActivity {
         public void onFinish(Object value) {
             chatLogs = (ChatLogs) value;
             if (chatLogs.getMembersId().size() == 2) {
-                String otherId = getOtherID();
-                otherLoc = new MLocation(otherId);
+                otherLoc = new MLocation(getOtherID());
                 database.readObjOnce(otherLoc, Database.Tables.LOCATIONS, otherLocationCallback);
             }
             if (chatLogs.getMembersId().size() < 2 && otherUserId != null) {
@@ -363,7 +325,7 @@ public class MessageListActivity extends AppCompatActivity {
         if(chatId == null) return;
 
         if(!isChatRunning.containsKey(chatId)){
-            final chatState state = new chatState();
+            final ChatState state = new ChatState();
             isChatRunning.put(chatId, state);
             return;
         }

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/MapUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/MapUtility.java
@@ -36,6 +36,7 @@ public class MapUtility implements DBLocationObserver {
     private static final int LOC_PERMIT_REQUEST_CODE = 1234;
     private static final double DEFAULT_LATITUDE = 46.5191;
     private static final double DEFAULT_LONGITUDE = 6.5668;
+    private boolean positionChanged = false;
 
     private static FusedLocationProviderClient mblFusedLocationClient;
     private static boolean mblLocationPermissionGranted;
@@ -83,7 +84,7 @@ public class MapUtility implements DBLocationObserver {
         mblFusedLocationClient = LocationServices.getFusedLocationProviderClient( activity);
         try {
             if ( mblLocationPermissionGranted) {
-                Task location = mblFusedLocationClient.getLastLocation();
+                final Task location = mblFusedLocationClient.getLastLocation();
                 location.addOnCompleteListener(new OnCompleteListener() {
                     @Override
                     public void onComplete(@NonNull Task task) {
@@ -91,6 +92,8 @@ public class MapUtility implements DBLocationObserver {
                             currentLocation = (Location) task.getResult();
                             LatLng currentCoordinates = new LatLng( currentLocation.getLatitude(), currentLocation.getLongitude());
                             setCurrCoordinates(currentCoordinates);
+                            positionChanged = true;
+
                         }
                         else {
                             Toast.makeText( activity.getApplicationContext(), "Unable to get current location",
@@ -129,7 +132,16 @@ public class MapUtility implements DBLocationObserver {
     public void setCurrCoordinates(LatLng curCoordinates) {
         UserInfo.getInstance().getCurrentPosition().setLatitude(currCoordinates.latitude);
         UserInfo.getInstance().getCurrentPosition().setLongitude(currCoordinates.longitude);
-        UserInfo.getInstance().updateLocationInDB();
+
+        Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(),
+                Database.Tables.LOCATIONS,
+                "latitude",
+                curCoordinates.latitude);
+
+        Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(),
+                Database.Tables.LOCATIONS,
+                "longitude",
+                curCoordinates.longitude);
         currCoordinates = curCoordinates;
     }
 
@@ -216,6 +228,7 @@ public class MapUtility implements DBLocationObserver {
     public void onLocationChange(String id){
         myPos = UserInfo.getInstance().getCurrentPosition();
         otherPos = OthersInfo.getInstance().getUsersInRadius();
+
     }
 }
 

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/MapUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/MapUtility.java
@@ -37,7 +37,6 @@ public class MapUtility implements DBLocationObserver {
     private static final int LOC_PERMIT_REQUEST_CODE = 1234;
     private static final double DEFAULT_LATITUDE = 46.5191;
     private static final double DEFAULT_LONGITUDE = 6.5668;
-    private boolean positionChanged = false;
 
     private static FusedLocationProviderClient mblFusedLocationClient;
     private static boolean mblLocationPermissionGranted;
@@ -89,7 +88,6 @@ public class MapUtility implements DBLocationObserver {
                             currentLocation = (Location) task.getResult();
                             LatLng currentCoordinates = new LatLng( currentLocation.getLatitude(), currentLocation.getLongitude());
                             setCurrCoordinates(currentCoordinates);
-                            positionChanged = true;
 
                         }
                         else {

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -1,21 +1,27 @@
 package ch.epfl.sweng.radius.utils;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
+import android.os.Build;
 import android.support.v4.app.NotificationCompat;
+import android.support.v7.app.AppCompatActivity;
 
 import ch.epfl.sweng.radius.R;
 
-public class NotificationUtility {
+public class NotificationUtility{
 
     private static int unseenMsg = 0;
     private static int unseenReq = 0;
     private Context context;
     private String channelID;
+    private NotificationManager notificationManager;
 
-    public NotificationUtility(Context context, String chanelID){
+    public NotificationUtility(Context context, String chanelID, NotificationManager notificationManager){
         this.context = context;
         this.channelID = chanelID;
+        this.notificationManager = notificationManager;
 
 
     }

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -1,0 +1,48 @@
+package ch.epfl.sweng.radius.utils;
+
+import android.app.Notification;
+import android.content.Context;
+import android.support.v4.app.NotificationCompat;
+
+import ch.epfl.sweng.radius.R;
+
+public class NotificationUtility {
+
+    private static int unseenMsg = 0;
+    private static int unseenReq = 0;
+    private Context context;
+    private String channelID;
+
+    public NotificationUtility(Context context, String chanelID){
+        this.context = context;
+        this.channelID = chanelID;
+
+
+    }
+
+    public void resetUnseenMsg(){
+        unseenMsg = 0;
+    }
+
+    public void resetUnseenReq(){
+        unseenMsg = 0;
+    }
+
+    public void notifyNewMessage(String chatID, String senderID) {
+        unseenMsg++;
+        NotificationCompat.Builder msgNotifBuilder = new NotificationCompat.Builder(context, channelID)
+                .setSmallIcon(R.drawable.fui_ic_mail_white_24dp)
+                .setContentTitle("Radius Chat")
+                .setContentText("New Message in "+ chatID + " from " + senderID)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+    }
+
+    public void notifyNewFrienReq(String userID, String userNickname) {
+        unseenMsg++;
+        NotificationCompat.Builder msgNotifBuilder = new NotificationCompat.Builder(context, channelID)
+                .setSmallIcon(R.drawable.fui_ic_mail_white_24dp)
+                .setContentTitle("Radius")
+                .setContentText("New Friend Request from "+ userNickname + " (" + userID+")")
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+    }
+}

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -2,17 +2,15 @@ package ch.epfl.sweng.radius.utils;
 
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.content.Context;
+import android.content.Intent;
 import android.support.v4.app.NotificationCompat;
 
 import ch.epfl.sweng.radius.R;
 
-public class NotificationUtility{
+public class NotificationUtility {
 
     private static int unseenMsg = 0;
     private static int unseenReq = 0;
-    private Context context;
-    private String channelID;
     private  NotificationManager notificationManager;
     private  NotificationCompat.Builder msgNotifBuilder;
     private NotificationCompat.Builder reqNotifBuilder;
@@ -24,14 +22,12 @@ public class NotificationUtility{
 
         this.msgNotifBuilder = msgNotif
                 .setSmallIcon(R.mipmap.ic_launcher_foreground)
-                .setContentTitle("Radius Chat")
-                .setTicker("Radius")
+                .setContentTitle("Radius")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true);
         this.reqNotifBuilder = reqNotif
                 .setSmallIcon(R.mipmap.ic_launcher_foreground)
                 .setContentTitle("Radius")
-                .setTicker("Radius")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true);
     }
@@ -56,11 +52,10 @@ public class NotificationUtility{
 
 
     public void notifyNewMessage(String senderId, String content, PendingIntent pi) {
-
-         msgNotifBuilder.setContentText("New Message from " + senderId + " : " + content + "...")
+         msgNotifBuilder.setContentText("New Message : " + content)
                  .setContentIntent(pi)
-                .setSmallIcon(android.R.drawable.ic_dialog_email)
-                .setContentTitle("Radius Chat");
+                 .setSmallIcon(android.R.drawable.ic_dialog_email)
+                 .setContentTitle(senderId);
         unseenMsg++;
         notificationManager.notify(1, msgNotifBuilder.build());
     }

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -1,19 +1,11 @@
 package ch.epfl.sweng.radius.utils;
 
-import android.app.Activity;
-import android.app.Notification;
-import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
-import android.content.res.Resources;
-import android.os.Build;
 import android.support.v4.app.NotificationCompat;
-import android.support.v7.app.AppCompatActivity;
 
 import ch.epfl.sweng.radius.R;
-import ch.epfl.sweng.radius.messages.MessageListActivity;
 
 public class NotificationUtility{
 
@@ -33,11 +25,13 @@ public class NotificationUtility{
         this.msgNotifBuilder = msgNotif
                 .setSmallIcon(R.mipmap.ic_launcher_foreground)
                 .setContentTitle("Radius Chat")
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setAutoCancel(true);
         this.reqNotifBuilder = reqNotif
                 .setSmallIcon(R.mipmap.ic_launcher_foreground)
                 .setContentTitle("Radius")
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setAutoCancel(true);
     }
 
     public static NotificationUtility getInstance(NotificationManager nm, NotificationCompat.Builder msgNotif, NotificationCompat.Builder reqNotif){
@@ -46,16 +40,16 @@ public class NotificationUtility{
         return instance;
     }
 
-    public static void resetUnseenMsg(){
+    public void resetUnseenMsg(){
         unseenMsg = 0;
     }
 
-    public static void resetUnseenReq(){
+    public void resetUnseenReq(){
         unseenMsg = 0;
     }
 
     public static void clearSeenMsg(int num){
-        unseenMsg -= num;
+        if(unseenMsg >= num) unseenMsg -= num;
     }
 
 
@@ -65,15 +59,18 @@ public class NotificationUtility{
                 .setTicker("Radius")
                 .setSmallIcon(android.R.drawable.ic_menu_report_image)
                 .setContentTitle("Radius")
-                .setContentIntent(pi)
-                .setAutoCancel(true);
+                .setContentIntent(pi);
         unseenMsg++;
         notificationManager.notify(1, msgNotifBuilder.build());
     }
 
-    public void notifyNewFrienReq(String userID, String userNickname) {
+    public void notifyNewFrienReq(String userID, String userNickname, PendingIntent pi) {
         unseenMsg++;
-        reqNotifBuilder.setContentText("New Friend Request from "+ userNickname + " (" + userID+")");
+        reqNotifBuilder.setContentText("New Friend Request from "+ userNickname + " (" + userID+")")
+                .setTicker("Radius")
+                .setSmallIcon(android.R.drawable.ic_menu_report_image)
+                .setContentTitle("Radius")
+                .setContentIntent(pi);
         notificationManager.notify(2, reqNotifBuilder.build());
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -25,11 +25,13 @@ public class NotificationUtility{
         this.msgNotifBuilder = msgNotif
                 .setSmallIcon(R.mipmap.ic_launcher_foreground)
                 .setContentTitle("Radius Chat")
+                .setTicker("Radius")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true);
         this.reqNotifBuilder = reqNotif
                 .setSmallIcon(R.mipmap.ic_launcher_foreground)
                 .setContentTitle("Radius")
+                .setTicker("Radius")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true);
     }
@@ -56,10 +58,9 @@ public class NotificationUtility{
     public void notifyNewMessage(String senderId, String content, PendingIntent pi) {
 
          msgNotifBuilder.setContentText("New Message from " + senderId + " : " + content + "...")
-                .setTicker("Radius")
-                .setSmallIcon(android.R.drawable.ic_menu_report_image)
-                .setContentTitle("Radius")
-                .setContentIntent(pi);
+                 .setContentIntent(pi)
+                .setSmallIcon(android.R.drawable.ic_dialog_email)
+                .setContentTitle("Radius Chat");
         unseenMsg++;
         notificationManager.notify(1, msgNotifBuilder.build());
     }
@@ -67,9 +68,8 @@ public class NotificationUtility{
     public void notifyNewFrienReq(String userID, String userNickname, PendingIntent pi) {
         unseenMsg++;
         reqNotifBuilder.setContentText("New Friend Request from "+ userNickname + " (" + userID+")")
-                .setTicker("Radius")
-                .setSmallIcon(android.R.drawable.ic_menu_report_image)
-                .setContentTitle("Radius")
+                .setSmallIcon(android.R.drawable.alert_dark_frame)
+                .setContentTitle("Radius Friend Request")
                 .setContentIntent(pi);
         notificationManager.notify(2, reqNotifBuilder.build());
     }

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -46,13 +46,18 @@ public class NotificationUtility{
         return instance;
     }
 
-    public void resetUnseenMsg(){
+    public static void resetUnseenMsg(){
         unseenMsg = 0;
     }
 
-    public void resetUnseenReq(){
+    public static void resetUnseenReq(){
         unseenMsg = 0;
     }
+
+    public static void clearSeenMsg(int num){
+        unseenMsg -= num;
+    }
+
 
     public void notifyNewMessage(String chatID, String senderID, PendingIntent pi) {
 

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -31,11 +31,11 @@ public class NotificationUtility{
         this.notificationManager = nm;
 
         this.msgNotifBuilder = msgNotif
-                .setSmallIcon(R.drawable.fui_ic_mail_white_24dp)
+                .setSmallIcon(R.mipmap.ic_launcher_foreground)
                 .setContentTitle("Radius Chat")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT);
         this.reqNotifBuilder = reqNotif
-                .setSmallIcon(R.drawable.fui_ic_mail_white_24dp)
+                .setSmallIcon(R.mipmap.ic_launcher_foreground)
                 .setContentTitle("Radius")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT);
     }
@@ -59,16 +59,15 @@ public class NotificationUtility{
     }
 
 
-    public void notifyNewMessage(String chatID, String senderID, PendingIntent pi) {
+    public void notifyNewMessage(String senderId, String content, PendingIntent pi) {
 
-         msgNotifBuilder.setContentText("New Message in "+ chatID + " from " + senderID)
+         msgNotifBuilder.setContentText("New Message from " + senderId + " : " + content + "...")
                 .setTicker("Radius")
                 .setSmallIcon(android.R.drawable.ic_menu_report_image)
                 .setContentTitle("Radius")
                 .setContentIntent(pi)
                 .setAutoCancel(true);
         unseenMsg++;
-        msgNotifBuilder.setContentText("New Message in "+ chatID + " from " + senderID);
         notificationManager.notify(1, msgNotifBuilder.build());
     }
 

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -1,14 +1,19 @@
 package ch.epfl.sweng.radius.utils;
 
+import android.app.Activity;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 import android.support.v7.app.AppCompatActivity;
 
 import ch.epfl.sweng.radius.R;
+import ch.epfl.sweng.radius.messages.MessageListActivity;
 
 public class NotificationUtility{
 
@@ -16,14 +21,29 @@ public class NotificationUtility{
     private static int unseenReq = 0;
     private Context context;
     private String channelID;
-    private NotificationManager notificationManager;
-
-    public NotificationUtility(Context context, String chanelID, NotificationManager notificationManager){
-        this.context = context;
-        this.channelID = chanelID;
-        this.notificationManager = notificationManager;
+    private  NotificationManager notificationManager;
+    private  NotificationCompat.Builder msgNotifBuilder;
+    private NotificationCompat.Builder reqNotifBuilder;
+    private static NotificationUtility instance;
 
 
+    public NotificationUtility(NotificationManager nm, NotificationCompat.Builder msgNotif, NotificationCompat.Builder reqNotif){
+        this.notificationManager = nm;
+
+        this.msgNotifBuilder = msgNotif
+                .setSmallIcon(R.drawable.fui_ic_mail_white_24dp)
+                .setContentTitle("Radius Chat")
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+        this.reqNotifBuilder = reqNotif
+                .setSmallIcon(R.drawable.fui_ic_mail_white_24dp)
+                .setContentTitle("Radius")
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+    }
+
+    public static NotificationUtility getInstance(NotificationManager nm, NotificationCompat.Builder msgNotif, NotificationCompat.Builder reqNotif){
+        if(instance == null)
+            instance = new NotificationUtility(nm, msgNotif, reqNotif);
+        return instance;
     }
 
     public void resetUnseenMsg(){
@@ -34,21 +54,22 @@ public class NotificationUtility{
         unseenMsg = 0;
     }
 
-    public void notifyNewMessage(String chatID, String senderID) {
+    public void notifyNewMessage(String chatID, String senderID, PendingIntent pi) {
+
+         msgNotifBuilder.setContentText("New Message in "+ chatID + " from " + senderID)
+                .setTicker("Radius")
+                .setSmallIcon(android.R.drawable.ic_menu_report_image)
+                .setContentTitle("Radius")
+                .setContentIntent(pi)
+                .setAutoCancel(true);
         unseenMsg++;
-        NotificationCompat.Builder msgNotifBuilder = new NotificationCompat.Builder(context, channelID)
-                .setSmallIcon(R.drawable.fui_ic_mail_white_24dp)
-                .setContentTitle("Radius Chat")
-                .setContentText("New Message in "+ chatID + " from " + senderID)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+        msgNotifBuilder.setContentText("New Message in "+ chatID + " from " + senderID);
+        notificationManager.notify(1, msgNotifBuilder.build());
     }
 
     public void notifyNewFrienReq(String userID, String userNickname) {
         unseenMsg++;
-        NotificationCompat.Builder msgNotifBuilder = new NotificationCompat.Builder(context, channelID)
-                .setSmallIcon(R.drawable.fui_ic_mail_white_24dp)
-                .setContentTitle("Radius")
-                .setContentText("New Friend Request from "+ userNickname + " (" + userID+")")
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+        reqNotifBuilder.setContentText("New Friend Request from "+ userNickname + " (" + userID+")");
+        notificationManager.notify(2, reqNotifBuilder.build());
     }
 }

--- a/app/src/test/java/ch/epfl/sweng/radius/home/HomeFragmentTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/home/HomeFragmentTest.java
@@ -191,6 +191,12 @@ public class HomeFragmentTest {
     }
 
     @Test
+    public void initMap(){
+        fragment.initMap();
+    }
+
+
+    @Test
     public void testOnMapReady(){
   //  try {
         fragment.onMapReady(mockMap);

--- a/app/src/test/java/ch/epfl/sweng/radius/messages/ChatStateTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/messages/ChatStateTest.java
@@ -1,0 +1,29 @@
+package ch.epfl.sweng.radius.messages;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ChatStateTest {
+
+    private ChatState test;
+
+    @Before
+    public void setUp() throws Exception {
+        test = new ChatState();
+    }
+
+    @Test
+    public void allMethodsTest() {
+        test.msgReceived();
+        assertEquals(0, test.getUnreadMsg());
+        test.leaveActivity();
+        test.msgReceived();
+        assertEquals(1, test.getUnreadMsg());
+        assertFalse(test.isRunning());
+        test.clear();
+        assertTrue(test.isRunning());
+        assertEquals(0, test.getUnreadMsg());
+    }
+}

--- a/app/src/test/java/ch/epfl/sweng/radius/utils/NotificationUtilityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/utils/NotificationUtilityTest.java
@@ -1,0 +1,71 @@
+package ch.epfl.sweng.radius.utils;
+
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.graphics.drawable.Icon;
+import android.support.v4.app.NotificationCompat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class NotificationUtilityTest {
+
+    private static NotificationUtility test;
+    private NotificationManager mockedManager = Mockito.mock(NotificationManager.class);
+    private NotificationCompat.Builder mockedBuilder = Mockito.mock(NotificationCompat.Builder.class);
+    private PendingIntent mockedIntent = Mockito.mock(PendingIntent.class);
+    @Before
+    public void setUp() throws Exception {
+
+        when(mockedBuilder.setSmallIcon(anyInt())).thenReturn(mockedBuilder);
+        when(mockedBuilder.setTicker(any(CharSequence.class))).thenReturn(mockedBuilder);
+        when(mockedBuilder.setPriority(anyInt())).thenReturn(mockedBuilder);
+        when(mockedBuilder.setAutoCancel(anyBoolean())).thenReturn(mockedBuilder);
+        when(mockedBuilder.setContentTitle(anyString())).thenReturn(mockedBuilder);
+        when(mockedBuilder.setContentText(anyString())).thenReturn(mockedBuilder);
+        when(mockedBuilder.setContentIntent(any(PendingIntent.class))).thenReturn(mockedBuilder);
+        test = NotificationUtility.getInstance(mockedManager, mockedBuilder, mockedBuilder);
+
+    }
+
+    @Test
+    public void getInstance() {
+        NotificationUtility.getInstance(mockedManager, mockedBuilder, mockedBuilder);
+        NotificationUtility.getInstance(null, null, null);
+    }
+
+    @Test
+    public void resetUnseenMsg() {
+        test.resetUnseenMsg();
+    }
+
+    @Test
+    public void resetUnseenReq() {
+        test.resetUnseenReq();
+    }
+
+    @Test
+    public void clearSeenMsg() {
+        NotificationUtility.clearSeenMsg(1);
+    }
+
+    @Test
+    public void notifyNewMessage() {
+        test.notifyNewMessage("0", "okok", mockedIntent);
+    }
+
+    @Test
+    public void notifyNewFrienReq() {
+        test.notifyNewFrienReq("0", "okok", mockedIntent);
+
+    }
+}


### PR DESCRIPTION
Implementation of the feature displaying Notification when a Message is received and the user is outside the conversation view.

#### Created : 
`NotificationUtility` : Centralizes the notification creation, display and event count
`ChatState` : simple _boolean_ , _int_ pair that is used statically (max 1 per chatId) in MessageListActivity to keep track of activities activity as well as unread message count
#### Modified : 
`MessageListActivity`  : Added the notification option upon message reception
`MLocation` : Modified default ID
`OthersInfo` : Fix userInRadius List by not adding own location to List
`AccountActivity` : Initialize NotificationUtility and Notification Channel upon creation
`others`TBD

#### Current State : 
> Notification are showed correctly (Sender Nickname + Start of MessageContent) but still no in-app graphic element (e.g. circle with message count).
> Clicking on Notification opens new MessageListActivity corresponding to conversation