### PR TITLE
Fixed null reference that made the app crash

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customGroups/CustomGroupTab.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customGroups/CustomGroupTab.java
@@ -37,8 +37,10 @@ public abstract class CustomGroupTab extends CustomTab {
                     // The groupId serves also as a name
                     groupsItems.add(new CustomListItem(groupId, convId, groupId));
                 }
-                adapter.setItems(groupsItems);
-                adapter.notifyDataSetChanged();
+                if(adapter != null){
+                    adapter.setItems(groupsItems);
+                    adapter.notifyDataSetChanged();
+                }
 
             }
             @Override

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customTopics/CustomTopicTab.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customTopics/CustomTopicTab.java
@@ -39,8 +39,10 @@ public abstract class CustomTopicTab extends CustomTab {
                     convId = topics.getChatLogsId();
                     topicItems.add(new CustomListItem(topicId, convId, topicId));
                 }
-                adapter.setItems(topicItems);
-                adapter.notifyDataSetChanged();
+                if(adapter != null){
+                    adapter.setItems(topicItems);
+                    adapter.notifyDataSetChanged();
+                }
             }
 
             @Override

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserTab.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserTab.java
@@ -43,8 +43,8 @@ public abstract class CustomUserTab extends CustomTab implements DBLocationObser
             }
       //  database.readListObjOnce(listIds,
       //          Database.Tables.USERS, getAdapterCallback());
-        adapter.setItems(usersItems);
-        adapter.notifyDataSetChanged();
+
+
     }
 
     @Override


### PR DESCRIPTION
Little fix to a bug that made the app crash : 

Sometime, when going back to PeopleTab, the adapter was called before being re-instanciated (the instance was probably thrown out). Simply checking if null avoids this issue without modifiying the GUI as it is quickly instantiated shortly after the user goes back to it.