### PR TITLE
Fix user status in user tab

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesActivityTest.java
@@ -103,16 +103,12 @@ public class BrowseProfilesActivityTest extends ActivityInstrumentationTestCase2
         assertNotNull(view);
         view = mActivity.findViewById(R.id.add_user);
         assertNotNull(view);
-        view = mActivity.findViewById(R.id.block_user);
-        assertNotNull(view);
     }
 
     @Test
     public void testAddFriends() {
         Espresso.onView(withId(R.id.add_user)).perform(click());
-        //Try clicking again
         Espresso.onView(withId(R.id.add_user)).perform(click());
-        //assertTrue(UserInfo.getInstance().getCurrentUser().getFriendsRequests().contains("testUser2"));
     }
 
     @After

--- a/app/src/androidTest/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesUnblockedActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesUnblockedActivityTest.java
@@ -15,31 +15,30 @@ import org.junit.Test;
 
 import ch.epfl.sweng.radius.R;
 import ch.epfl.sweng.radius.database.Database;
-import ch.epfl.sweng.radius.database.UserInfo;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-public class BrowseProfilesActivityTest extends ActivityInstrumentationTestCase2<BrowseProfilesActivity> {
+public class BrowseProfilesUnblockedActivityTest extends ActivityInstrumentationTestCase2<BrowseProfilesUnblockedActivity> {
     @Rule
-    public final ActivityTestRule<BrowseProfilesActivity> mActivityRule =
-            new ActivityTestRule<>(BrowseProfilesActivity.class);
+    public final ActivityTestRule<BrowseProfilesUnblockedActivity> mActivityRule =
+            new ActivityTestRule<>(BrowseProfilesUnblockedActivity.class);
 
-    private BrowseProfilesActivity mblBrowseProfilesActivity;
+    private BrowseProfilesUnblockedActivity mblBrowseProfilesUnblockedActivity;
 
-    public BrowseProfilesActivityTest(){
-        super(BrowseProfilesActivity.class);
+    public BrowseProfilesUnblockedActivityTest(){
+        super(BrowseProfilesUnblockedActivity.class);
     }
 
-    private BrowseProfilesActivity mActivity;
+    private BrowseProfilesUnblockedActivity mActivity;
 
     @Rule
     public final GrantPermissionRule mPermissionRule = GrantPermissionRule.grant(
             Manifest.permission.ACCESS_FINE_LOCATION);
 
-    public BrowseProfilesActivityTest(Class<BrowseProfilesActivity> activityClass) {
+    public BrowseProfilesUnblockedActivityTest(Class<BrowseProfilesUnblockedActivity> activityClass) {
         super(activityClass);
     }
 
@@ -113,7 +112,7 @@ public class BrowseProfilesActivityTest extends ActivityInstrumentationTestCase2
 
     @After
     public void tearDown() throws Exception {
-        mblBrowseProfilesActivity = null;
+        mblBrowseProfilesUnblockedActivity = null;
     }
 
 }

--- a/app/src/androidTest/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesUnblockedActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesUnblockedActivityTest.java
@@ -71,7 +71,7 @@ public class BrowseProfilesUnblockedActivityTest extends ActivityInstrumentation
         onView(withText("Options")).perform(click());
         onView(withText("Block User")).perform(click());
         onView(withText("Options")).perform(click());
-        onView(withText("Unblock user")).perform(click());
+        onView(withText("Unblock User")).perform(click());
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
             android:name=".AccountActivity"
             android:screenOrientation="portrait" />
         <activity
-            android:name=".browseProfiles.BrowseProfilesActivity"
+            android:name=".browseProfiles.BrowseProfilesUnblockedActivity"
             android:screenOrientation="portrait" />
         <activity
             android:name=".browseProfiles.BrowseProfilesBlockedActivity"
@@ -52,6 +52,8 @@
         <uses-library
             android:name="org.apache.http.legacy"
             android:required="false" />
+
+        <activity android:name=".browseProfiles.BrowseProfilesActivity"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesActivity.java
@@ -107,10 +107,14 @@ public class BrowseProfilesActivity extends AppCompatActivity{
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
         getMenuInflater().inflate(R.menu.profile_menu, menu);
+        setUpUnblockButton(menu);
+        return true;
+    }
+
+    private void setUpUnblockButton(Menu menu) {
         if (UserInfo.getInstance().getCurrentUser().getBlockedUsers().contains(userUID)) {
             menu.getItem(0).getSubMenu().getItem(0).setTitle("Unblock User");
         }
-        return true;
     }
 
     @Override

--- a/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesActivity.java
@@ -1,106 +1,25 @@
 package ch.epfl.sweng.radius.browseProfiles;
 
-import android.content.Intent;
-import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.TextView;
-import android.widget.Toast;
-
-import com.google.firebase.database.DatabaseError;
-import com.squareup.picasso.Picasso;
 
 import ch.epfl.sweng.radius.R;
-import ch.epfl.sweng.radius.database.CallBackDatabase;
-import ch.epfl.sweng.radius.database.Database;
-import ch.epfl.sweng.radius.database.GroupLocationFetcher;
-import ch.epfl.sweng.radius.database.MLocation;
-import ch.epfl.sweng.radius.database.OthersInfo;
-import ch.epfl.sweng.radius.database.User;
 import ch.epfl.sweng.radius.database.UserInfo;
 import ch.epfl.sweng.radius.utils.BrowseProfilesUtility;
 
-
-public class BrowseProfilesActivity extends AppCompatActivity{
-    //Might want to create and get the id of users along with their names.
-    private BrowseProfilesUtility profileActivityListener;
-    private Toolbar toolbar;
-    private final Database database = Database.getInstance();
-    private String userUID;
-    private String userNickname;
-
-    // UI elements
-    private ImageView userPhoto;
-    private TextView textViewName;
-    private TextView textViewStatus;
-    private TextView textViewInterests;
-    private TextView textViewLanguages;
+public abstract class BrowseProfilesActivity extends AppCompatActivity {
+    protected BrowseProfilesUtility profileActivityListener;
+    protected String userUID;
+    protected Toolbar toolbar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_browse_profiles);
-        Intent intent = getIntent();
-
-        //profileActivityListener = new BrowseProfilesUtility(intent.getStringExtra("Clicked Name")); // WHEN THE CLASS STORES THE ID OF THE USER WE
-        // CLICKED ON CHANGE CLICKED NAME WITH THE ID
-
-        // Initialize UI Components
-        userNickname = intent.getStringExtra("Clicked Name");
-        userUID = intent.getStringExtra("UID");
-        profileActivityListener = new BrowseProfilesUtility(userUID);
-        userPhoto = findViewById(R.id.userPhoto);
-        textViewName = findViewById(R.id.userNickname);
-        textViewStatus = findViewById(R.id.userStatus);
-        textViewInterests = findViewById(R.id.userInterests);
-        textViewLanguages = findViewById(R.id.userLanguages);
-        toolbar = findViewById(R.id.toolbar);
-
-        fetchUserInfo(userUID);
-
-        // ToolBar initialization
-        setSupportActionBar(toolbar);
-    }
-
-
-    void fetchUserInfo(String userUID){
-
-        final MLocation targetUser = OthersInfo.getInstance().getUsersInRadius().get(userUID) != null ?
-                OthersInfo.getInstance().getUsersInRadius().get(userUID):
-                OthersInfo.getInstance().getConvUsers().get(userUID);
-
-        database.readObjOnce(new User(userUID), Database.Tables.USERS, new CallBackDatabase() {
-            @Override
-            public void onFinish(Object value) {
-                // Get the current user profile from the DB
-                User current_profile = (User) value;
-                setUpAddFriendButton(current_profile);
-                setUpUIComponents(targetUser);
-            }
-
-            @Override
-            public void onError(DatabaseError error) {
-
-            }
-        });
-        }
-
-    public void setUpUIComponents(MLocation current_user){
-        if (current_user != null && current_user.getUrlProfilePhoto() != null && !current_user.getUrlProfilePhoto().equals("")) {
-            Picasso.get().load(current_user.getUrlProfilePhoto()).into(userPhoto);
-            textViewName.setText(current_user.getTitle());
-            textViewStatus.setText(current_user.getMessage());
-            textViewInterests.setText(current_user.getInterests());
-            textViewLanguages.setText(current_user.getSpokenLanguages());
-        } else {
-            userPhoto.setImageResource(R.drawable.user_photo_default);
-        }
+        setContentView(R.layout.activity_browse_profiles2);
     }
 
     @Override
@@ -123,10 +42,11 @@ public class BrowseProfilesActivity extends AppCompatActivity{
             case R.id.block_user:
                 if (item.getTitle().toString().trim().equals("Block User")) {
                     profileActivityListener.blockUser();
-                    item.setTitle("Unblock user");
+                    item.setTitle("Unblock User");
                 } else if (item.getTitle().toString().trim().equals("Unblock User")) {
                     profileActivityListener.unblockUser();
                     item.setTitle("Block User");
+                    Log.e("BrowseProfilesActivity:", "Unblocking user");
                 }
                 return true;
             case R.id.spam:
@@ -138,30 +58,5 @@ public class BrowseProfilesActivity extends AppCompatActivity{
             default:
                 return super.onOptionsItemSelected(item);
         }
-    }
-
-    private void setUpAddFriendButton(final User profileUser){
-        final Button addFriendButton = findViewById(R.id.add_user);
-        final User currentUser = UserInfo.getInstance().getCurrentUser();
-        if (currentUser.getFriends().containsKey(profileUser.getID())) {
-            addFriendButton.setText("Remove friend"); addFriendButton.setEnabled(true);
-        }
-        else if (currentUser.getFriendsRequests().containsKey(profileUser.getID())) {
-            addFriendButton.setText("Request sent"); addFriendButton.setEnabled(false);
-        }
-        addFriendButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-
-                if (currentUser.getFriends().containsKey(profileUser.getID())) {
-                    addFriendButton.setText("Add Friend"); addFriendButton.setEnabled(true);
-                } else {
-                    currentUser.addFriendRequest(profileUser);
-                    UserInfo.getInstance().updateUserInDB();
-                    database.writeInstanceObj(profileUser, Database.Tables.USERS);
-                    addFriendButton.setText("Request sent"); addFriendButton.setEnabled(false);
-                }
-            }
-        });
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesBlockedActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesBlockedActivity.java
@@ -18,5 +18,7 @@ public class BrowseProfilesBlockedActivity extends BrowseProfilesActivity {
         userUID = intent.getStringExtra("UID");
         profileActivityListener = new BrowseProfilesUtility(userUID);
         toolbar = findViewById(R.id.toolbar);
+
+        setSupportActionBar(toolbar);
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesBlockedActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesBlockedActivity.java
@@ -1,15 +1,22 @@
 package ch.epfl.sweng.radius.browseProfiles;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 
 import ch.epfl.sweng.radius.R;
+import ch.epfl.sweng.radius.utils.BrowseProfilesUtility;
 
-public class BrowseProfilesBlockedActivity extends AppCompatActivity {
+public class BrowseProfilesBlockedActivity extends BrowseProfilesActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_browse_profiles_blocked);
+        Intent intent = getIntent();
+
+        userUID = intent.getStringExtra("UID");
+        profileActivityListener = new BrowseProfilesUtility(userUID);
+        toolbar = findViewById(R.id.toolbar);
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesUnblockedActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/browseProfiles/BrowseProfilesUnblockedActivity.java
@@ -1,0 +1,164 @@
+package ch.epfl.sweng.radius.browseProfiles;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.google.firebase.database.DatabaseError;
+import com.squareup.picasso.Picasso;
+
+import ch.epfl.sweng.radius.R;
+import ch.epfl.sweng.radius.database.CallBackDatabase;
+import ch.epfl.sweng.radius.database.Database;
+import ch.epfl.sweng.radius.database.GroupLocationFetcher;
+import ch.epfl.sweng.radius.database.MLocation;
+import ch.epfl.sweng.radius.database.OthersInfo;
+import ch.epfl.sweng.radius.database.User;
+import ch.epfl.sweng.radius.database.UserInfo;
+import ch.epfl.sweng.radius.utils.BrowseProfilesUtility;
+
+
+public class BrowseProfilesUnblockedActivity extends BrowseProfilesActivity{
+    //Might want to create and get the id of users along with their names.
+    //private BrowseProfilesUtility profileActivityListener;
+    //private Toolbar toolbar;
+    private final Database database = Database.getInstance();
+    //private String userUID;
+    private String userNickname;
+
+    // UI elements
+    private ImageView userPhoto;
+    private TextView textViewName;
+    private TextView textViewStatus;
+    private TextView textViewInterests;
+    private TextView textViewLanguages;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_browse_profiles);
+        Intent intent = getIntent();
+
+        // Initialize UI Components
+        userNickname = intent.getStringExtra("Clicked Name");
+        userUID = intent.getStringExtra("UID");
+        profileActivityListener = new BrowseProfilesUtility(userUID);
+        userPhoto = findViewById(R.id.userPhoto);
+        textViewName = findViewById(R.id.userNickname);
+        textViewStatus = findViewById(R.id.userStatus);
+        textViewInterests = findViewById(R.id.userInterests);
+        textViewLanguages = findViewById(R.id.userLanguages);
+        toolbar = findViewById(R.id.toolbar);
+
+        fetchUserInfo(userUID);
+
+        // ToolBar initialization
+        setSupportActionBar(toolbar);
+    }
+
+
+    void fetchUserInfo(String userUID){
+
+        final MLocation targetUser = OthersInfo.getInstance().getUsersInRadius().get(userUID) != null ?
+                OthersInfo.getInstance().getUsersInRadius().get(userUID):
+                OthersInfo.getInstance().getConvUsers().get(userUID);
+
+        database.readObjOnce(new User(userUID), Database.Tables.USERS, new CallBackDatabase() {
+            @Override
+            public void onFinish(Object value) {
+                // Get the current user profile from the DB
+                User current_profile = (User) value;
+                setUpAddFriendButton(current_profile);
+                setUpUIComponents(targetUser);
+            }
+
+            @Override
+            public void onError(DatabaseError error) {
+
+            }
+        });
+        }
+
+    public void setUpUIComponents(MLocation current_user){
+        if (current_user != null && current_user.getUrlProfilePhoto() != null && !current_user.getUrlProfilePhoto().equals("")) {
+            Picasso.get().load(current_user.getUrlProfilePhoto()).into(userPhoto);
+            textViewName.setText(current_user.getTitle());
+            textViewStatus.setText(current_user.getMessage());
+            textViewInterests.setText(current_user.getInterests());
+            textViewLanguages.setText(current_user.getSpokenLanguages());
+        } else {
+            userPhoto.setImageResource(R.drawable.user_photo_default);
+        }
+    }
+
+    /*@Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        getMenuInflater().inflate(R.menu.profile_menu, menu);
+        setUpUnblockButton(menu);
+        return true;
+    }
+
+    private void setUpUnblockButton(Menu menu) {
+        if (UserInfo.getInstance().getCurrentUser().getBlockedUsers().contains(userUID)) {
+            menu.getItem(0).getSubMenu().getItem(0).setTitle("Unblock User");
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.block_user:
+                if (item.getTitle().toString().trim().equals("Block User")) {
+                    profileActivityListener.blockUser();
+                    item.setTitle("Unblock user");
+                } else if (item.getTitle().toString().trim().equals("Unblock User")) {
+                    profileActivityListener.unblockUser();
+                    item.setTitle("Block User");
+                }
+                return true;
+            case R.id.spam:
+                profileActivityListener.reportUser("spam");
+                return true;
+            case R.id.language:
+                profileActivityListener.reportUser("language");
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }*/
+
+    private void setUpAddFriendButton(final User profileUser){
+        final Button addFriendButton = findViewById(R.id.add_user);
+        final User currentUser = UserInfo.getInstance().getCurrentUser();
+        if (currentUser.getFriends().containsKey(profileUser.getID())) {
+            addFriendButton.setText("Remove friend"); addFriendButton.setEnabled(true);
+        }
+        else if (currentUser.getFriendsRequests().containsKey(profileUser.getID())) {
+            addFriendButton.setText("Request sent"); addFriendButton.setEnabled(false);
+        }
+        addFriendButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+                if (currentUser.getFriends().containsKey(profileUser.getID())) {
+                    addFriendButton.setText("Add Friend"); addFriendButton.setEnabled(true);
+                } else {
+                    currentUser.addFriendRequest(profileUser);
+                    UserInfo.getInstance().updateUserInDB();
+                    database.writeInstanceObj(profileUser, Database.Tables.USERS);
+                    addFriendButton.setText("Request sent"); addFriendButton.setEnabled(false);
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
+import android.media.Image;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.ActivityCompat;
@@ -17,6 +18,8 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -58,6 +61,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
     private TabAdapter adapter;
     private TabLayout tabLayout;
     private ViewPager viewPager;
+    private ImageView zoomInButton;
 
     //testing
     public static MapUtility mapListener = MapUtility.getMapInstance();
@@ -110,13 +114,16 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
         // Create the tab layout under the map
         viewPager = view.findViewById(R.id.viewPager);
         tabLayout = view.findViewById(R.id.tabLayout);
+
         adapter = new TabAdapter(this.getChildFragmentManager());
         adapter.addFragment(new PeopleTab(), "People");
         adapter.addFragment(new GroupTab(), "Groups");
         adapter.addFragment(new TopicsTab(), "Topics");
+
         viewPager.setAdapter(adapter);
         tabLayout.setupWithViewPager(viewPager);
         getReadWritePermission(getContext(), getActivity());
+
         return view;
     }
 
@@ -140,6 +147,19 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
         mapView.onCreate(savedInstanceState);
         mapView.onResume();
         mapView.getMapAsync(this);
+
+        setUpZoomButton(view);
+    }
+
+    private void setUpZoomButton(View view) {
+        zoomInButton = view.findViewById(R.id.zoomButton);
+        zoomInButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                if (coord != null) {
+                    moveCamera(coord, ZOOM);
+                }
+            }
+        });
     }
 
     @Override
@@ -163,7 +183,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
                 return;
             }
 
-            mobileMap.setMyLocationEnabled(true);
+            //mobileMap.setMyLocationEnabled(true);
             try
             {
                 getActivity().runOnUiThread(new Runnable(){

--- a/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
@@ -84,7 +84,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
     }*/
 
     // For debug purpose only
-    /*public static HomeFragment newInstance(MapUtility mapUtility, GoogleMap googleMap,
+    public static HomeFragment newInstance(MapUtility mapUtility, GoogleMap googleMap,
                                            int radiusValue) {
         HomeFragment fragment = new HomeFragment();
         radius = radiusValue;
@@ -93,7 +93,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
         coord = new LatLng(UserInfo.getInstance().getCurrentPosition().getLatitude(),
                 UserInfo.getInstance().getCurrentPosition().getLongitude());
         return fragment;
-    }*/
+    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -147,10 +147,6 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
         mapView.onResume();
         mapView.getMapAsync(this);
 
-        setUpZoomButton(view);
-    }
-
-    private void setUpZoomButton(View view) {
         zoomInButton = view.findViewById(R.id.zoomButton);
         zoomInButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
@@ -160,6 +156,17 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
             }
         });
     }
+
+    /*private void setUpZoomButton(View view) {
+        zoomInButton = view.findViewById(R.id.zoomButton);
+        zoomInButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                if (coord != null) {
+                    moveCamera(coord, ZOOM);
+                }
+            }
+        });
+    }*/
 
     @Override
     public void onMapReady(GoogleMap googleMap) {

--- a/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
@@ -112,16 +112,12 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
         View view = infltr.inflate(R.layout.fragment_home, container, false);
 
         // Create the tab layout under the map
-        viewPager = view.findViewById(R.id.viewPager);
-        tabLayout = view.findViewById(R.id.tabLayout);
+        viewPager = view.findViewById(R.id.viewPager); tabLayout = view.findViewById(R.id.tabLayout);
 
         adapter = new TabAdapter(this.getChildFragmentManager());
-        adapter.addFragment(new PeopleTab(), "People");
-        adapter.addFragment(new GroupTab(), "Groups");
-        adapter.addFragment(new TopicsTab(), "Topics");
+        adapter.addFragment(new PeopleTab(), "People"); adapter.addFragment(new GroupTab(), "Groups"); adapter.addFragment(new TopicsTab(), "Topics");
 
-        viewPager.setAdapter(adapter);
-        tabLayout.setupWithViewPager(viewPager);
+        viewPager.setAdapter(adapter); tabLayout.setupWithViewPager(viewPager);
         getReadWritePermission(getContext(), getActivity());
 
         return view;
@@ -202,8 +198,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
 
             MLocation curPos = UserInfo.getInstance().getCurrentPosition();
             coord = new LatLng(curPos.getLatitude(), curPos.getLongitude());
-            initCircle(coord);
-            moveCamera(coord, ZOOM);
+            initCircle(coord); moveCamera(coord, ZOOM);
 
             // Do locations here
             markNearbyUsers();
@@ -252,15 +247,12 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
     public void markNearbyUsers() {
 
         // Clear Markers
-      //  mapMarkers.removeAll(mapMarkers);
         try
         {
             getActivity().runOnUiThread(new Runnable(){
                 public void run(){
                     if(mobileMap != null){
-                        mobileMap.clear();
-
-                        mobileMap.addCircle(radiusOptions);
+                        mobileMap.clear(); mobileMap.addCircle(radiusOptions);
                     }
 
                 }

--- a/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
@@ -204,24 +204,6 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
             coord = new LatLng(curPos.getLatitude(), curPos.getLongitude());
             initCircle(coord);
             moveCamera(coord, ZOOM);
-            // Push current location to DB
-            // Write the location of the current user to the database
-            /*
-            Database.getInstance().readObjOnce(new MLocation("EPFL"), Database.Tables.LOCATIONS, new CallBackDatabase() {
-                @Override
-                public void onFinish(Object value) {
-                    MLocation epfl2 = (MLocation) value;
-                    epfl2.setLocationType(1);
-                    epfl2.setRadius(2000);
-                    Database.getInstance().writeInstanceObj(epfl2, Database.Tables.LOCATIONS);
-                }
-
-                @Override
-                public void onError(DatabaseError error) {
-
-                }
-            });*/
-          //  mapListener.setMyPos(myPos);
 
             // Do locations here
             markNearbyUsers();

--- a/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/home/HomeFragment.java
@@ -75,16 +75,16 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
      * @return A new instance of fragment SettingsFragment.
      */
     // TODO: Rename and change types and number of parameters
-    public static HomeFragment newInstance() {
+    /*public static HomeFragment newInstance() {
         HomeFragment fragment = new HomeFragment();
         radius = UserInfo.getInstance().getCurrentPosition().getRadius(); // converting to meters.
         coord = new LatLng(UserInfo.getInstance().getCurrentPosition().getLatitude(),
                 UserInfo.getInstance().getCurrentPosition().getLongitude());
         return fragment;
-    }
+    }*/
 
     // For debug purpose only
-    public static HomeFragment newInstance(MapUtility mapUtility, GoogleMap googleMap,
+    /*public static HomeFragment newInstance(MapUtility mapUtility, GoogleMap googleMap,
                                            int radiusValue) {
         HomeFragment fragment = new HomeFragment();
         radius = radiusValue;
@@ -93,7 +93,7 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
         coord = new LatLng(UserInfo.getInstance().getCurrentPosition().getLatitude(),
                 UserInfo.getInstance().getCurrentPosition().getLongitude());
         return fragment;
-    }
+    }*/
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -112,10 +112,13 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
         View view = infltr.inflate(R.layout.fragment_home, container, false);
 
         // Create the tab layout under the map
-        viewPager = view.findViewById(R.id.viewPager); tabLayout = view.findViewById(R.id.tabLayout);
+        viewPager = view.findViewById(R.id.viewPager);
+        tabLayout = view.findViewById(R.id.tabLayout);
 
         adapter = new TabAdapter(this.getChildFragmentManager());
-        adapter.addFragment(new PeopleTab(), "People"); adapter.addFragment(new GroupTab(), "Groups"); adapter.addFragment(new TopicsTab(), "Topics");
+        adapter.addFragment(new PeopleTab(), "People");
+        adapter.addFragment(new GroupTab(), "Groups");
+        adapter.addFragment(new TopicsTab(), "Topics");
 
         viewPager.setAdapter(adapter); tabLayout.setupWithViewPager(viewPager);
         getReadWritePermission(getContext(), getActivity());
@@ -198,7 +201,8 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback, DBLoca
 
             MLocation curPos = UserInfo.getInstance().getCurrentPosition();
             coord = new LatLng(curPos.getLatitude(), curPos.getLongitude());
-            initCircle(coord); moveCamera(coord, ZOOM);
+            initCircle(coord);
+            moveCamera(coord, ZOOM);
 
             // Do locations here
             markNearbyUsers();

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
@@ -44,8 +44,8 @@ public class MessageListActivity extends AppCompatActivity {
     private Button sendButton;
     private ChatLogs chatLogs;
     private String chatId, otherUserId, myID;
-    //these might cause problems when we switch to multiple users and multiple different chats
-    //This field will be used to enable chat with FRIENDS not in radius
+    private int locType;
+
     private MLocation otherLoc;
     private Database database;
     private static HashMap<String, ChatState> isChatRunning = new HashMap<>();
@@ -127,6 +127,7 @@ public class MessageListActivity extends AppCompatActivity {
             otherUserId = b.getString("otherId");
             chatLogs = new ChatLogs(chatId);
             database.readObjOnce(chatLogs, Database.Tables.CHATLOGS, chatLogCallBack);
+            locType = b.getInt("locType");
             Log.e("message", "Setup Messages size" + Integer.toString(chatLogs.getMessages().size()));
         } else {
             throw new RuntimeException("MessagListActivity Intent created without bundle");
@@ -284,26 +285,8 @@ public class MessageListActivity extends AppCompatActivity {
     }
 
     private void compareLocataion() {
-        /*TODO check if other users radius contains current user.
-           The problem here is, if the other user is in my radius I can send messages to them, however, if current user
-           is not in the radius of the other user, they can not reply to those messages.*//*
-        MLocation location = OthersInfo.getInstance().getGroupsPos().get(chatId);
-        if(location != null){
-            // If the Chat is a groupChat
-            setEnabled(true);
-        }
-        else{
-            for(String s : chatLogs.getMembersId()){
-                if(s != UserInfo.getInstance().getCurrentUser().getID())
-                    location = OthersInfo.getInstance().getUsersInRadius().get(s);
-            }
-            if(location != null)
-                setEnabled(true);
-            else
-                setEnabled(false);
-        }
-        */
-        if(chatLogs.getMembersId().size() == 2) {
+        //TODO check if other users radius contains current user.
+        if (locType == 0) {//chatLogs.getMembersId().size() == 2) {
             //System.out.println("ABCCD " + otherUserId);
             //System.out.println(OthersInfo.getInstance().getUsersInRadius().containsKey(otherUserId));//get(otherUserId);//.getLatitude();
             //System.out.println("ABCCD " + OthersInfo.getInstance().getUsersInRadius().get(otherUserId).getLatitude() + " " + OthersInfo.getInstance().getUsersInRadius().get(otherUserId).getLongitude());

--- a/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/messages/MessageListActivity.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import ch.epfl.sweng.radius.R;
 import ch.epfl.sweng.radius.database.CallBackDatabase;
@@ -284,13 +283,12 @@ public class MessageListActivity extends AppCompatActivity {
         });
     }
 
-    private void compareLocataion() {
+    private void compareLocation() {
         //TODO check if other users radius contains current user.
-        if (locType == 0) {//chatLogs.getMembersId().size() == 2) {
-            //System.out.println("ABCCD " + otherUserId);
-            //System.out.println(OthersInfo.getInstance().getUsersInRadius().containsKey(otherUserId));//get(otherUserId);//.getLatitude();
-            //System.out.println("ABCCD " + OthersInfo.getInstance().getUsersInRadius().get(otherUserId).getLatitude() + " " + OthersInfo.getInstance().getUsersInRadius().get(otherUserId).getLongitude());
-            setEnabled(OthersInfo.getInstance().getUsersInRadius().containsKey(otherUserId) && !OthersInfo.getInstance().getUsers().get(otherUserId).getBlockedUsers().contains(UserInfo.getInstance().getCurrentUser().getID()));
+        if (locType == 0) {
+            setEnabled(OthersInfo.getInstance().getUsersInRadius().containsKey(otherUserId) &&
+                    !OthersInfo.getInstance().getUsers().get(otherUserId).getBlockedUsers().
+                            contains(UserInfo.getInstance().getCurrentUser().getID()));
         }
         else {
             setEnabled(true);
@@ -305,7 +303,7 @@ public class MessageListActivity extends AppCompatActivity {
         prepareUsers(participants);
 
         //compare the locations of the users and whether they are able to talk to each other or not.
-        compareLocataion();
+        compareLocation();
 
     }
 

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customGroups/CustomGroupListListeners.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customGroups/CustomGroupListListeners.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 import ch.epfl.sweng.radius.messages.MessageListActivity;
 
 public class CustomGroupListListeners {
+    private static final int LOCATION_TYPE = 1;
     private String groupId;
     private String groupName;
     private String convId;
@@ -30,6 +31,7 @@ public class CustomGroupListListeners {
                 b.putString("chatId", convId);
                 b.putString("groupId", groupId);
                 b.putString("groupName", groupName);
+                b.putInt("locType", LOCATION_TYPE);
                 intent.putExtras(b);
                 context.startActivity(intent);
 

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customTopics/CustomTopicListAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customTopics/CustomTopicListAdapter.java
@@ -22,6 +22,7 @@ import ch.epfl.sweng.radius.R;
 import ch.epfl.sweng.radius.database.ChatLogs;
 import ch.epfl.sweng.radius.database.Database;
 import ch.epfl.sweng.radius.database.MLocation;
+import ch.epfl.sweng.radius.database.OthersInfo;
 import ch.epfl.sweng.radius.database.UserInfo;
 import ch.epfl.sweng.radius.utils.customLists.CustomListAdapter;
 import ch.epfl.sweng.radius.utils.customLists.CustomListItem;

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customTopics/CustomTopicListListeners.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customTopics/CustomTopicListListeners.java
@@ -9,7 +9,7 @@ import android.widget.TextView;
 import ch.epfl.sweng.radius.messages.MessageListActivity;
 
 public class CustomTopicListListeners {
-
+    private static final int LOCATION_TYPE = 2;
     private String topicId;
     private String topicName;
     private String convId;
@@ -29,6 +29,7 @@ public class CustomTopicListListeners {
                 bundle.putString("chatId", convId);
                 bundle.putString("topicId", topicId);
                 bundle.putString("topicName", topicName);
+                bundle.putInt("locType", LOCATION_TYPE);
                 intent.putExtras(bundle);
                 context.startActivity(intent);
             }

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserListAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserListAdapter.java
@@ -23,28 +23,12 @@ public class CustomUserListAdapter extends CustomListAdapter {
     // Replace the contents of a view (invoked by the layout manager)
     @Override
     public void onBindViewHolder(ViewHolder viewHolder, int position) {
-//        Log.e("CustomUserListAdapter", "Items users size :" + items.size());
 
         CustomListItem item = items.get(position);
- //       Log.e("CustomUserListAdapter", "Item users ID :" + item.getItemId());
-//        Log.e("CustomUserListAdapter", "Item position :" + position);
-
         viewHolder.txtViewTitle.setText(item.getItemName());
+        viewHolder.txtViewStatus.setText();
 
-/*
-        if (OthersInfo.getInstance().getUsers().get(item.getItemId()).getUrlProfilePhoto() != null &&
-                !OthersInfo.getInstance().getUsers().get(item.getItemId()).getUrlProfilePhoto().equals("")) {
-            Picasso.get().load
-                    (OthersInfo.getInstance().
-                            getUsers().get(item.getItemId()).getUrlProfilePhoto()).
-                    into(viewHolder.imgViewIcon);
-        } else {
-            viewHolder.imgViewIcon.setImageResource(items.get(position).getProfilePic());
-        }
-*/
         MLocation itemUser = OthersInfo.getInstance().getAllUserLocations().get(item.getItemId());
-
-        Log.e("CustomUserListAdapter", "-----------------------------------People Tab-------------------------------------");
 
         if(itemUser != null){
             if (!itemUser.getUrlProfilePhoto().isEmpty()) {

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserListAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserListAdapter.java
@@ -25,10 +25,10 @@ public class CustomUserListAdapter extends CustomListAdapter {
     public void onBindViewHolder(ViewHolder viewHolder, int position) {
 
         CustomListItem item = items.get(position);
-        viewHolder.txtViewTitle.setText(item.getItemName());
-        viewHolder.txtViewStatus.setText();
-
         MLocation itemUser = OthersInfo.getInstance().getAllUserLocations().get(item.getItemId());
+
+        viewHolder.txtViewTitle.setText(item.getItemName());
+        viewHolder.txtViewStatus.setText(itemUser.getMessage());
 
         if(itemUser != null){
             if (!itemUser.getUrlProfilePhoto().isEmpty()) {

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserListListeners.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserListListeners.java
@@ -24,6 +24,7 @@ import ch.epfl.sweng.radius.database.UserInfo;
 import ch.epfl.sweng.radius.messages.MessageListActivity;
 
 public class CustomUserListListeners {
+    private final static int LOCATION_TYPE = 0;
     private final Database database = Database.getInstance();
     private int clickedPic;
     private String clickedName;
@@ -91,6 +92,7 @@ public class CustomUserListListeners {
         Bundle b = new Bundle();
         b.putString("chatId", chatId);
         b.putString("otherId", userId);
+        b.putInt("locType", LOCATION_TYPE);
         intent.putExtras(b); context.startActivity(intent);
     }
 

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserListListeners.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/customUsers/CustomUserListListeners.java
@@ -13,7 +13,7 @@ import com.google.firebase.database.DatabaseError;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import ch.epfl.sweng.radius.browseProfiles.BrowseProfilesActivity;
+import ch.epfl.sweng.radius.browseProfiles.BrowseProfilesUnblockedActivity;
 import ch.epfl.sweng.radius.browseProfiles.BrowseProfilesBlockedActivity;
 import ch.epfl.sweng.radius.database.CallBackDatabase;
 import ch.epfl.sweng.radius.database.ChatLogs;
@@ -46,7 +46,7 @@ public class CustomUserListListeners {
                 if (OthersInfo.getInstance().getUsers().get(userId).getBlockedUsers().contains(UserInfo.getInstance().getCurrentUser().getID())) {
                     intent = new Intent(context, BrowseProfilesBlockedActivity.class);
                 } else {
-                    intent = new Intent(context, BrowseProfilesActivity.class);
+                    intent = new Intent(context, BrowseProfilesUnblockedActivity.class);
                 }
 
                 intent.putExtra("Clicked Picture", clickedPic);

--- a/app/src/main/res/layout/activity_browse_profiles.xml
+++ b/app/src/main/res/layout/activity_browse_profiles.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".browseProfiles.BrowseProfilesActivity">
+    tools:context=".browseProfiles.BrowseProfilesUnblockedActivity">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_browse_profiles.xml
+++ b/app/src/main/res/layout/activity_browse_profiles.xml
@@ -82,17 +82,6 @@
         </RelativeLayout>
 
 
-
-        <Button
-            android:id="@+id/block_user"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="8dp"
-            android:text="BLOCK USER"
-            android:textAppearance="@style/TextAppearance.AppCompat.Button"
-            android:typeface="normal" />
-
         <Button
             android:id="@+id/add_user"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_browse_profiles2.xml
+++ b/app/src/main/res/layout/activity_browse_profiles2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".browseProfiles.BrowseProfilesActivity">
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_browse_profiles_blocked.xml
+++ b/app/src/main/res/layout/activity_browse_profiles_blocked.xml
@@ -6,6 +6,14 @@
     android:layout_height="match_parent"
     tools:context=".browseProfiles.BrowseProfilesBlockedActivity">
 
+    <include
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        layout="@layout/toolbar"
+        />
+
     <TextView
         android:id="@+id/blockedMessage"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -33,4 +33,15 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/zoomButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginEnd="22dp"
+        android:layout_marginTop="28dp"
+        android:src="@android:drawable/ic_menu_mylocation" />
+
 </RelativeLayout>

--- a/app/src/test/java/ch/epfl/sweng/radius/home/HomeFragmentTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/home/HomeFragmentTest.java
@@ -23,6 +23,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
@@ -166,9 +167,9 @@ public class HomeFragmentTest {
         Database.activateDebugMode();
 
         this.mapUtility = Mockito.mock(MapUtility.class);
-        this.fragment = HomeFragment.newInstance(mapUtility, mockMap, 50000);
+        /*this.fragment = HomeFragment.newInstance(mapUtility, mockMap, 50000);
         if(fragment == null)
-            System.out.print("ISNULL");
+            System.out.print("ISNULL");*/
 
     }
 
@@ -177,11 +178,12 @@ public class HomeFragmentTest {
         fragment.getFriendsID();
     }
 
-    @Test
+    /*@Test
+    @Ignore
     public void testNewInstance(){
 
         HomeFragment test = HomeFragment.newInstance();
-    }
+    }*/
 
     @Test
     public void markNearbyUser() {

--- a/app/src/test/java/ch/epfl/sweng/radius/home/HomeFragmentTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/home/HomeFragmentTest.java
@@ -167,9 +167,9 @@ public class HomeFragmentTest {
         Database.activateDebugMode();
 
         this.mapUtility = Mockito.mock(MapUtility.class);
-        /*this.fragment = HomeFragment.newInstance(mapUtility, mockMap, 50000);
+        this.fragment = HomeFragment.newInstance(mapUtility, mockMap, 50000);
         if(fragment == null)
-            System.out.print("ISNULL");*/
+            System.out.print("ISNULL");
 
     }
 
@@ -179,7 +179,6 @@ public class HomeFragmentTest {
     }
 
     /*@Test
-    @Ignore
     public void testNewInstance(){
 
         HomeFragment test = HomeFragment.newInstance();


### PR DESCRIPTION
I have fixed more than what the branch title implies.
. Refactored browse profiles activity and browse profiles blocked activity. Now browse profiles activity is called browse profiles unblocked activity and there is a parent called called browse profiles activity that currently only initializes the top toolbar. So, basically now people blocked by someone can report and block the person that blocked them. xd
. User tabs in people tabs, messages list, friends list etc. now show the user's actual status.
. Fixed the bug where if there were only two participants in group or topic chat the chat would be blocked. Now, ListListeners in customUsers, customGroups, customTopics pass the location type into the message activity and message activity only blocks private chats if one of the users is out of radius or blocked.
. Fixed the zoom widget by changing it with a custom one. When the user logs in for the very first time the map doesn't immediately zoom in on them but at least they can use this widget to zoom manually right away, unlike the last version.