### PR TITLE
Fix log out crash issue

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -119,18 +119,21 @@ public class PreferencesActivityTest  extends ActivityInstrumentationTestCase2<P
             e.printStackTrace();
         }
     }
-
-    /*
-
+/*
     @Test
     @Ignore
-    public void testDeleteAccount(){
+    public void testZDeleteAccount(){
         Espresso.onView(AllOf.allOf(withText(R.string.deleteAccountTitle)))
                 .perform(click());
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         Espresso.onView(withText("Delete")).perform(click());
 
     }
-*/
+    */
 
     @After
     public void tearDown() throws Exception {

--- a/app/src/androidTest/java/ch/epfl/sweng/radius/utils/DatabaseObjectsTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/utils/DatabaseObjectsTest.java
@@ -151,6 +151,7 @@ public class DatabaseObjectsTest {
 
     @Test
     public void testMLocation(){
+        MLocation loc = new MLocation();
         MLocation mLocation = new MLocation("testLoc0");
         MLocation mLocation1 = new MLocation("locTest");
         MLocation mLocation2 = new MLocation("locTest2", 2.0, 3.0);

--- a/app/src/androidTest/java/ch/epfl/sweng/radius/utils/DatabaseObjectsTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/radius/utils/DatabaseObjectsTest.java
@@ -151,7 +151,6 @@ public class DatabaseObjectsTest {
 
     @Test
     public void testMLocation(){
-        MLocation tep = new MLocation();
         MLocation mLocation = new MLocation("testLoc0");
         MLocation mLocation1 = new MLocation("locTest");
         MLocation mLocation2 = new MLocation("locTest2", 2.0, 3.0);

--- a/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
@@ -100,7 +100,7 @@ public class AccountActivity extends AppCompatActivity {
 
         timer = new Timer();
         // To load the current user infos
-        UserInfo.getInstance().fetchDataFromDB();
+        UserInfo.getInstance();//.fetchDataFromDB();
         OthersInfo.getInstance().fetchUsersInMyRadius();
         ChatlogsUtil.getInstance(getApplicationContext());
         // Set the layout
@@ -178,13 +178,16 @@ public class AccountActivity extends AppCompatActivity {
     }
 
     private void enterApp(){
+        Log.e("AccountActivity", "id: " + UserInfo.getInstance().getCurrentUser().getID());
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
         boolean incognito = settings.getBoolean("incognitoSwitch", false);
         Log.e("VISIBILITY", "Setting Visible to " + !incognito);
         UserInfo.getInstance().getCurrentPosition().setVisible(!incognito);
+        /*
         Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(),
                 Database.Tables.LOCATIONS, "visible",
-                !incognito);
+                !incognito);*/
+
     }
 
     @Override

--- a/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/AccountActivity.java
@@ -145,6 +145,8 @@ public class AccountActivity extends AppCompatActivity {
         });
 
         // ToolBar initialization
+        enterApp();
+
 
     }
 
@@ -158,7 +160,7 @@ public class AccountActivity extends AppCompatActivity {
             timer = new Timer();
             timerTask = new myTimer();
         }
-        enterApp();
+        UserInfo.getInstance().updateLocationInDB();
     }
 
     @Override
@@ -183,11 +185,7 @@ public class AccountActivity extends AppCompatActivity {
         boolean incognito = settings.getBoolean("incognitoSwitch", false);
         Log.e("VISIBILITY", "Setting Visible to " + !incognito);
         UserInfo.getInstance().getCurrentPosition().setVisible(!incognito);
-        /*
-        Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(),
-                Database.Tables.LOCATIONS, "visible",
-                !incognito);*/
-
+        UserInfo.getInstance().setIncognitoMode(incognito);
     }
 
     @Override

--- a/app/src/main/java/ch/epfl/sweng/radius/MainActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
 
     public static GoogleSignInClient googleSignInClient;
 
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
@@ -133,8 +133,8 @@ public class PreferencesActivity extends PreferenceActivity {
                             if (task.isSuccessful()) {
                                 Toast.makeText(getActivity(), "Account Deleted", Toast.LENGTH_SHORT).show();
                                 deleteUser();
-                                logOut();
                                 UserInfo.deleteDataStorage();
+                                logOut();
                                 //delete user
 
                             } else {
@@ -223,13 +223,10 @@ public class PreferencesActivity extends PreferenceActivity {
                     .addOnCompleteListener(getActivity(), new OnCompleteListener<Void>() {
                         @Override
                         public void onComplete(@NonNull Task<Void> task) {
-                            Intent intent = new Intent(getActivity().getApplicationContext(), MainActivity.class);
-                            int mPendingIntentId = 182;
-                            PendingIntent mPendingIntent = PendingIntent.getActivity(getActivity().getApplicationContext(), mPendingIntentId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
-                            AlarmManager mgr = (AlarmManager) getActivity().getApplicationContext().getSystemService(Context.ALARM_SERVICE);
-                            mgr.set(AlarmManager.RTC, System.currentTimeMillis() + 100, mPendingIntent);
-                            System.exit(0);
-
+                            Intent intent = new Intent(getActivity(), MainActivity.class);
+                            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                            startActivity(intent);
                         }
                     });
         }

--- a/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
@@ -71,6 +71,8 @@ public class PreferencesActivity extends PreferenceActivity {
 
         public void logOut() {
             if (MainActivity.googleSignInClient != null) {
+                UserInfo.getInstance().getCurrentPosition().setVisible(false);
+                UserInfo.getInstance().updateLocationInDB();
                 FirebaseAuth.getInstance().signOut();
                 MainActivity.googleSignInClient.signOut()
                         .addOnCompleteListener(getActivity(), new OnCompleteListener<Void>() {

--- a/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
@@ -1,6 +1,9 @@
 package ch.epfl.sweng.radius;
 
+import android.app.AlarmManager;
 import android.app.AlertDialog;
+import android.app.PendingIntent;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -82,6 +85,8 @@ public class PreferencesActivity extends PreferenceActivity {
                             }
                         });
             }
+
+
         }
 
         private void setupDeleteAccountButton() {
@@ -118,10 +123,11 @@ public class PreferencesActivity extends PreferenceActivity {
         * Deletes account and takes the user to the sign in page
         * */
         public void setupPositiveButton(AlertDialog.Builder dialog) {
+            final FirebaseAuth auth = FirebaseAuth.getInstance();
             dialog.setPositiveButton("Delete", new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
-                    FirebaseAuth.getInstance().getCurrentUser().delete().addOnCompleteListener(new OnCompleteListener<Void>() {
+                    auth.getCurrentUser().delete().addOnCompleteListener(new OnCompleteListener<Void>() {
                         @Override
                         public void onComplete(@NonNull Task<Void> task) {
                             if (task.isSuccessful()) {
@@ -217,7 +223,13 @@ public class PreferencesActivity extends PreferenceActivity {
                     .addOnCompleteListener(getActivity(), new OnCompleteListener<Void>() {
                         @Override
                         public void onComplete(@NonNull Task<Void> task) {
-                            startActivity(new Intent(getActivity(), MainActivity.class));
+                            Intent intent = new Intent(getActivity().getApplicationContext(), MainActivity.class);
+                            int mPendingIntentId = 182;
+                            PendingIntent mPendingIntent = PendingIntent.getActivity(getActivity().getApplicationContext(), mPendingIntentId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                            AlarmManager mgr = (AlarmManager) getActivity().getApplicationContext().getSystemService(Context.ALARM_SERVICE);
+                            mgr.set(AlarmManager.RTC, System.currentTimeMillis() + 100, mPendingIntent);
+                            System.exit(0);
+
                         }
                     });
         }

--- a/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
@@ -170,10 +170,6 @@ public class PreferencesActivity extends PreferenceActivity {
         @Override
         public void onPause() {
             super.onPause();
-            UserInfo.getInstance().getCurrentPosition().setVisible(false);
-            Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(),
-                    Database.Tables.LOCATIONS, "visible",
-                    true);
             getPreferenceScreen()
                     .getSharedPreferences()
                     .unregisterOnSharedPreferenceChangeListener(this);

--- a/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/PreferencesActivity.java
@@ -19,6 +19,7 @@ import com.google.firebase.auth.FirebaseAuth;
 
 import ch.epfl.sweng.radius.database.Database;
 import ch.epfl.sweng.radius.database.MLocation;
+import ch.epfl.sweng.radius.database.User;
 import ch.epfl.sweng.radius.database.UserInfo;
 
 public class PreferencesActivity extends PreferenceActivity {
@@ -125,6 +126,7 @@ public class PreferencesActivity extends PreferenceActivity {
                                 Toast.makeText(getActivity(), "Account Deleted", Toast.LENGTH_SHORT).show();
                                 deleteUser();
                                 logOut();
+                                UserInfo.deleteDataStorage();
                                 //delete user
 
                             } else {

--- a/app/src/main/java/ch/epfl/sweng/radius/database/FirebaseUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/FirebaseUtility.java
@@ -199,6 +199,7 @@ public class FirebaseUtility extends Database{
 
     @Override
     public void readAllTableOnce(final Tables tableName, final CallBackDatabase callback) {
+     //   Log.e("Firebase Debug", "Caller :" + printStack());
         FirebaseDatabase.getInstance()
                 .getReference(tableName.toString())
                 .addListenerForSingleValueEvent( new ValueEventListener() {
@@ -243,13 +244,12 @@ public class FirebaseUtility extends Database{
 
 
 /*
+    private String printStack(){
         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
         String res = "";
         for (int i = 0; i < trace.length  && i < 30; i++)
             res +=  trace[i].getClassName() + "." + trace[i].getMethodName() + ":" + trace[i].getLineNumber() + "\n";
         return res;
     }
-
-    */
-
+*/
 }

--- a/app/src/main/java/ch/epfl/sweng/radius/database/FirebaseUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/FirebaseUtility.java
@@ -12,6 +12,7 @@ import android.support.v4.util.Pair;
 import android.util.Log;
 
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -67,7 +68,12 @@ public class FirebaseUtility extends Database{
 
     @Override
     public String getCurrent_user_id() {
-            return FirebaseAuth.getInstance().getCurrentUser().getUid();
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user != null)
+            return user.getUid();
+        else
+            return null;
+
 
     }
 

--- a/app/src/main/java/ch/epfl/sweng/radius/database/FirebaseUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/FirebaseUtility.java
@@ -243,13 +243,14 @@ public class FirebaseUtility extends Database{
 
 
 
-/*
-    private String printStack(){
+    public String getStack(){
         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
         String res = "";
         for (int i = 0; i < trace.length  && i < 30; i++)
             res +=  trace[i].getClassName() + "." + trace[i].getMethodName() + ":" + trace[i].getLineNumber() + "\n";
         return res;
     }
-*/
+
+
+
 }

--- a/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
@@ -24,13 +24,11 @@ public class MLocation implements DatabaseObject, Serializable {
     private double radius; // Use it only if the mLocation is a group.
     private String spokenLanguages;
     private String interests;
-    private ArrayList<String> languageList;
+    private ArrayList<String> languageList = new ArrayList<>();
 
     private String ownerId = ""; // for topics, no significance for locations and groups (so default is "")
 
-    public MLocation(){
-        this(Database.getInstance().getCurrent_user_id());
-    }
+    public MLocation(){}
 
     public MLocation(String userID){
         this(userID,DEFAULT_LONGITUDE,DEFAULT_lATITUDE);
@@ -48,7 +46,6 @@ public class MLocation implements DatabaseObject, Serializable {
         this.urlProfilePhoto = DEFAULT_URL_PROFIL_PIC;
         this.spokenLanguages = "";
         this.interests = "";
-        this.languageList = new ArrayList<>();
     }
 
     public double getLatitude() {

--- a/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
@@ -11,7 +11,7 @@ public class MLocation implements DatabaseObject, Serializable {
     private final static String DEFAULT_URL_PROFIL_PIC = "https://firebasestorage.googleapis.com/v0/b/radius-1538126456577.appspot.com/o/profilePictures%2Fdefault.png?alt=media&token=ccd39de0-9921-487b-90e7-3501262d7835";
 
 
-    private String userID;
+    private String userID = "";
     private String title;
     private String message;
     private double longitude;
@@ -26,9 +26,9 @@ public class MLocation implements DatabaseObject, Serializable {
     private String interests;
     private ArrayList<String> languageList = new ArrayList<>();
 
-    private String ownerId = ""; // for topics, no significance for locations and groups (so default is "")
+    private String ownerId; // for topics, no significance for locations and groups (so default is "")
 
-    public MLocation(){}
+    public MLocation(){this("");}
 
     public MLocation(String userID){
         this(userID,DEFAULT_LONGITUDE,DEFAULT_lATITUDE);

--- a/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/MLocation.java
@@ -1,5 +1,7 @@
 package ch.epfl.sweng.radius.database;
 
+import android.util.Log;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 
@@ -9,7 +11,6 @@ public class MLocation implements DatabaseObject, Serializable {
     private final static double DEFAULT_LONGITUDE = 6.5681216000000004;
     private final static double DEFAULT_lATITUDE = 46.5160698;
     private final static String DEFAULT_URL_PROFIL_PIC = "https://firebasestorage.googleapis.com/v0/b/radius-1538126456577.appspot.com/o/profilePictures%2Fdefault.png?alt=media&token=ccd39de0-9921-487b-90e7-3501262d7835";
-
 
     private String userID = "";
     private String title;
@@ -32,6 +33,8 @@ public class MLocation implements DatabaseObject, Serializable {
 
     public MLocation(String userID){
         this(userID,DEFAULT_LONGITUDE,DEFAULT_lATITUDE);
+
+        Log.e("Debug MLocation", "User ID is" + userID);
     }
 
     public MLocation(String userID, double longitude, double latitude){

--- a/app/src/main/java/ch/epfl/sweng/radius/database/UserInfo.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/UserInfo.java
@@ -23,6 +23,7 @@ public  class UserInfo extends DBObservable implements Serializable{
 
     private User current_user;
     private MLocation current_position;
+    private boolean incognitoMode;
 
     public static UserInfo getInstance(){
         if (userInfo == null) {
@@ -36,6 +37,10 @@ public  class UserInfo extends DBObservable implements Serializable{
         current_position = new MLocation(Database.getInstance().getCurrent_user_id());
         fetchDataFromDB();
 
+    }
+
+    public void setIncognitoMode(boolean incognitoMode) {
+        this.incognitoMode = incognitoMode;
     }
 
     public void fetchDataFromDB(){
@@ -74,6 +79,9 @@ public  class UserInfo extends DBObservable implements Serializable{
                 current_position = (MLocation) loc;
                 Log.e("Firebase", ((MLocation) loc).getID());
                 notifyLocationObservers(Database.Tables.LOCATIONS.toString());
+
+                if (incognitoMode == current_position.getVisible())
+                    updateLocationInDB();
             }
 
             @Override

--- a/app/src/main/java/ch/epfl/sweng/radius/database/UserInfo.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/database/UserInfo.java
@@ -1,6 +1,8 @@
 package ch.epfl.sweng.radius.database;
 
+import android.content.SharedPreferences;
 import android.os.Environment;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import com.google.firebase.database.DatabaseError;
@@ -19,17 +21,21 @@ public  class UserInfo extends DBObservable implements Serializable{
     private static UserInfo userInfo = loadState();
     private static final Database database = Database.getInstance();
 
-    private static User current_user = new User(Database.getInstance().getCurrent_user_id(),
-            "", "");
-    private static MLocation current_position = new MLocation(Database.getInstance().getCurrent_user_id());
+    private User current_user;
+    private MLocation current_position;
 
     public static UserInfo getInstance(){
-        if (userInfo == null)
+        if (userInfo == null) {
             userInfo = new UserInfo();
+        }
         return userInfo;
     }
 
     private UserInfo(){
+        current_user = new User(Database.getInstance().getCurrent_user_id());
+        current_position = new MLocation(Database.getInstance().getCurrent_user_id());
+        fetchDataFromDB();
+
     }
 
     public void fetchDataFromDB(){
@@ -50,6 +56,7 @@ public  class UserInfo extends DBObservable implements Serializable{
             @Override
             public void onFinish(Object user) {
                 current_user = (User) user;
+                Log.e("Firebase", "TEST");
                 notifyUserObservers(Database.Tables.USERS.toString());
             }
 
@@ -65,6 +72,7 @@ public  class UserInfo extends DBObservable implements Serializable{
             @Override
             public void onFinish(Object loc) {
                 current_position = (MLocation) loc;
+                Log.e("Firebase", ((MLocation) loc).getID());
                 notifyLocationObservers(Database.Tables.LOCATIONS.toString());
             }
 
@@ -97,6 +105,13 @@ public  class UserInfo extends DBObservable implements Serializable{
         } catch (Exception e) {e.printStackTrace();}
         Log.e("SAVE STATE", "Loading the state");
         return savedUserInfo;
+    }
+
+    public static void deleteDataStorage(){
+        try {
+            File inFile = new File(Environment.getExternalStorageDirectory(), SAVE_PATH);
+            inFile.delete();
+        } catch (Exception e) {e.printStackTrace();}
     }
 
     public void updateUserInDB(){

--- a/app/src/main/java/ch/epfl/sweng/radius/profile/ProfileFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/profile/ProfileFragment.java
@@ -256,7 +256,6 @@ public class ProfileFragment extends Fragment implements DBUserObserver {
         String statusString = getDataFromTextInput(statusInput);
         String interestsString = getDataFromTextInput(interestsInput);
 
-        MLocation currentUser = UserInfo.getInstance().getCurrentPosition();
 
         nicknameString = nicknameString.replaceAll("[^A-Za-z0-9_]", "");
         nicknameString = truncateText(nicknameString,MAX_SIZE_USERNAME);
@@ -264,14 +263,16 @@ public class ProfileFragment extends Fragment implements DBUserObserver {
         interestsString = truncateText(interestsString,MAX_SIZE_INTERESTS);
 
         if (!nicknameString.isEmpty()) {
-            currentUser.setTitle(nicknameString);userNickname.setText(nicknameString);
+            UserInfo.getInstance().getCurrentPosition().setTitle(nicknameString);
+            userNickname.setText(nicknameString);
         }
         if (!statusString.isEmpty()) {
-            currentUser.setMessage(statusString);userStatus.setText(statusString);
+            UserInfo.getInstance().getCurrentPosition().setMessage(statusString);
+            userStatus.setText(statusString);
         }
 
         if (!interestsString.isEmpty()) {
-            currentUser.setInterests(interestsString);
+            UserInfo.getInstance().getCurrentPosition().setInterests(interestsString);
             userInterests.setText("Interests: " + interestsString);
         }
 
@@ -280,7 +281,8 @@ public class ProfileFragment extends Fragment implements DBUserObserver {
         }
 
         UserInfo.getInstance().getCurrentPosition().setRadius(userRadius);
-        currentUser.setRadius(userRadius);currentUser.setSpokenLanguages(languagesText);
+        UserInfo.getInstance().getCurrentPosition().setRadius(userRadius);
+        UserInfo.getInstance().getCurrentPosition().setSpokenLanguages(languagesText);
         spokenLanguages.setText(languagesText);
         //Write to DB
         UserInfo.getInstance().updateUserInDB();UserInfo.getInstance().updateLocationInDB();

--- a/app/src/main/java/ch/epfl/sweng/radius/profile/ProfileFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/profile/ProfileFragment.java
@@ -256,34 +256,28 @@ public class ProfileFragment extends Fragment implements DBUserObserver {
         String statusString = getDataFromTextInput(statusInput);
         String interestsString = getDataFromTextInput(interestsInput);
 
-
         nicknameString = nicknameString.replaceAll("[^A-Za-z0-9_]", "");
         nicknameString = truncateText(nicknameString,MAX_SIZE_USERNAME);
         statusString = truncateText(statusString,MAX_SIZE_STATUS);
         interestsString = truncateText(interestsString,MAX_SIZE_INTERESTS);
 
         if (!nicknameString.isEmpty()) {
-            UserInfo.getInstance().getCurrentPosition().setTitle(nicknameString);
-            userNickname.setText(nicknameString);
+            UserInfo.getInstance().getCurrentPosition().setTitle(nicknameString); userNickname.setText(nicknameString);
         }
         if (!statusString.isEmpty()) {
-            UserInfo.getInstance().getCurrentPosition().setMessage(statusString);
-            userStatus.setText(statusString);
+            UserInfo.getInstance().getCurrentPosition().setMessage(statusString); userStatus.setText(statusString);
         }
 
         if (!interestsString.isEmpty()) {
-            UserInfo.getInstance().getCurrentPosition().setInterests(interestsString);
-            userInterests.setText("Interests: " + interestsString);
+            UserInfo.getInstance().getCurrentPosition().setInterests(interestsString);userInterests.setText("Interests: " + interestsString);
         }
 
         if (Storage.getInstance().getStorageTask() == null || !Storage.getInstance().getStorageTask().isInProgress()) { // Upload the photo and its uri to storage and db
             Storage.getInstance().uploadFile( mImageUri, this.getActivity());
         }
 
-        UserInfo.getInstance().getCurrentPosition().setRadius(userRadius);
-        UserInfo.getInstance().getCurrentPosition().setRadius(userRadius);
-        UserInfo.getInstance().getCurrentPosition().setSpokenLanguages(languagesText);
-        spokenLanguages.setText(languagesText);
+        UserInfo.getInstance().getCurrentPosition().setRadius(userRadius);UserInfo.getInstance().getCurrentPosition().setRadius(userRadius);
+        UserInfo.getInstance().getCurrentPosition().setSpokenLanguages(languagesText);spokenLanguages.setText(languagesText);
         //Write to DB
         UserInfo.getInstance().updateUserInDB();UserInfo.getInstance().updateLocationInDB();
     }

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/MapUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/MapUtility.java
@@ -119,15 +119,17 @@ public class MapUtility implements DBLocationObserver {
     }
 
     public void setCurrCoordinates(LatLng curCoordinates) {
-        UserInfo.getInstance().getCurrentPosition().setLatitude(currCoordinates.latitude);
-        UserInfo.getInstance().getCurrentPosition().setLongitude(currCoordinates.longitude);
-        Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(), Database.Tables.LOCATIONS,
-                "latitude",
-                currCoordinates.latitude);
-        Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(), Database.Tables.LOCATIONS,
-                "longitude",
-                currCoordinates.longitude);
-        currCoordinates = curCoordinates;
+        if (UserInfo.getInstance().getCurrentPosition().getID() != "") {
+            UserInfo.getInstance().getCurrentPosition().setLatitude(currCoordinates.latitude);
+            UserInfo.getInstance().getCurrentPosition().setLongitude(currCoordinates.longitude);
+            Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(), Database.Tables.LOCATIONS,
+                    "latitude",
+                    currCoordinates.latitude);
+            Database.getInstance().writeToInstanceChild(UserInfo.getInstance().getCurrentPosition(), Database.Tables.LOCATIONS,
+                    "longitude",
+                    currCoordinates.longitude);
+            currCoordinates = curCoordinates;
+        }
     }
 
     public LatLng getCurrCoordinates() {

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/NotificationUtility.java
@@ -10,6 +10,7 @@ import ch.epfl.sweng.radius.database.ChatLogs;
 import ch.epfl.sweng.radius.database.Database;
 import ch.epfl.sweng.radius.database.Message;
 import ch.epfl.sweng.radius.database.OthersInfo;
+import ch.epfl.sweng.radius.database.UserInfo;
 
 public class NotificationUtility {
 
@@ -126,7 +127,7 @@ public class NotificationUtility {
     }
 
     private static String handleUserTitle(ChatLogs chatlogs) {
-        String currentUserId = Database.getInstance().getCurrent_user_id();
+        String currentUserId = UserInfo.getInstance().getCurrentUser().getID();
         String otherUserId = "";
         String ret = "Anonymous";
         for (String id : chatlogs.getMembersId()) {

--- a/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/CustomListAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/radius/utils/customLists/CustomListAdapter.java
@@ -82,8 +82,6 @@ public abstract class CustomListAdapter extends RecyclerView.Adapter<CustomListA
         }
         else
             Picasso.get().load(url).into(viewHolder.imgViewIcon);
-
-
     }
 
 

--- a/app/src/test/java/ch/epfl/sweng/radius/MainActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/MainActivityTest.java
@@ -1,10 +1,13 @@
 package ch.epfl.sweng.radius;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 
 import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
+import com.google.android.gms.auth.api.signin.GoogleSignInClient;
 import com.google.android.gms.auth.api.signin.GoogleSignInResult;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
@@ -20,11 +23,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -37,12 +43,14 @@ public class MainActivityTest {
     private Auth mock = Mockito.mock(Auth.class);
     private Intent mockedIntent = Mockito.mock(Intent.class);
     private MainActivity activity;
+    GoogleSignInClient mockedSignIn = Mockito.mock(GoogleSignInClient.class);
     private GoogleSignInResult mockedRes = Mockito.mock(GoogleSignInResult.class);
     private GoogleSignInAccount mockedAccount = Mockito.mock(GoogleSignInAccount.class);
     private FirebaseAuth mockedAuth = Mockito.mock(FirebaseAuth.class);
     ArgumentCaptor< OnCompleteListener> onCompleteArg = ArgumentCaptor.forClass(OnCompleteListener.class);
     ArgumentCaptor<Activity> aArg = ArgumentCaptor.forClass(Activity.class);
     Task<AuthResult> authRes = Mockito.mock(Task.class);
+    Task mockedTask = Mockito.mock(Task.class);
     @Before
     public void setUp() throws Exception {
         PowerMockito.mockStatic(FirebaseAuth.class);
@@ -61,6 +69,7 @@ public class MainActivityTest {
         when(authRes.isSuccessful()).thenReturn(true);
         activity = new MainActivity();
 
+
     }
 
     @After
@@ -70,6 +79,7 @@ public class MainActivityTest {
     @Test
     @Ignore
     public void onCreate() {
+
     }
 
     @Test

--- a/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -1,10 +1,12 @@
 package ch.epfl.sweng.radius;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.widget.Toast;
 
+import com.google.android.gms.auth.api.signin.GoogleSignInClient;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.FirebaseAuth;
@@ -109,6 +111,26 @@ public class PreferencesActivityTest {
         when(Toast.makeText(any(Context.class), any(CharSequence.class), anyInt())).thenReturn(mockedToast);
 
         test2.setupPositiveButton(mockedAler);
+    }
+
+    @Test
+    public void logOut(){
+        GoogleSignInClient mockedSignIn = Mockito.mock(GoogleSignInClient.class);
+        final Task mockedTask = Mockito.mock(Task.class);
+
+        MainActivity.googleSignInClient = mockedSignIn;
+
+
+        when(mockedSignIn.signOut()).thenReturn(mockedTask);
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                OnCompleteListener onCompleteListener = (OnCompleteListener) invocation.getArguments()[1];
+                onCompleteListener.onComplete(mockedTask);
+                return null;
+            }
+        }).when(mockedTask).addOnCompleteListener(any(Activity.class), any(OnCompleteListener.class));
+
     }
 
     private void restoreCurrentUser() {

--- a/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -118,7 +118,7 @@ public class PreferencesActivityTest {
 
         ObjectOutput out;
         try {
-            File outFile = new File(Environment.getExternalStorageDirectory(), SAVE_PATH);
+            File outFile = new File(SAVE_PATH);
             out = new ObjectOutputStream(new FileOutputStream(outFile));
             out.writeObject(this);
             out.close();
@@ -127,7 +127,7 @@ public class PreferencesActivityTest {
         test2.setupPositiveButton(mockedAler);
 
         try {
-            File outFile = new File(Environment.getExternalStorageDirectory(), SAVE_PATH);
+            File outFile = new File(SAVE_PATH);
             out = new ObjectOutputStream(new FileOutputStream(outFile));
             out.writeObject(this);
             out.close();

--- a/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -42,6 +42,7 @@ import ch.epfl.sweng.radius.database.Database;
 import ch.epfl.sweng.radius.database.FirebaseUtility;
 import ch.epfl.sweng.radius.database.MLocation;
 import ch.epfl.sweng.radius.database.User;
+import ch.epfl.sweng.radius.database.UserInfo;
 import ch.epfl.sweng.radius.messages.ChatState;
 
 import static org.mockito.Matchers.any;
@@ -120,7 +121,7 @@ public class PreferencesActivityTest {
         try {
             File outFile = new File(SAVE_PATH);
             out = new ObjectOutputStream(new FileOutputStream(outFile));
-            out.writeObject(this);
+            out.writeObject(null);
             out.close();
         } catch (Exception e) {e.printStackTrace();}
 
@@ -129,7 +130,7 @@ public class PreferencesActivityTest {
         try {
             File outFile = new File(SAVE_PATH);
             out = new ObjectOutputStream(new FileOutputStream(outFile));
-            out.writeObject(this);
+            out.writeObject(UserInfo.getInstance());
             out.close();
         } catch (Exception e) {e.printStackTrace();}
     }
@@ -143,6 +144,7 @@ public class PreferencesActivityTest {
 
 
         when(mockedSignIn.signOut()).thenReturn(mockedTask);
+        when(mockedSignIn.revokeAccess()).thenReturn(mockedTask);
         Mockito.doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.os.Environment;
 import android.widget.Toast;
 
 import com.google.android.gms.auth.api.signin.GoogleSignInClient;
@@ -29,6 +30,10 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -50,6 +55,7 @@ import static org.powermock.api.mockito.PowerMockito.doAnswer;
 @PowerMockRunnerDelegate(JUnit4.class)
 @PrepareForTest({ FirebaseAuth.class, Toast.class })
 public class PreferencesActivityTest {
+    private  final String SAVE_PATH = "current_user_info.data";
 
     private PreferencesActivity test;
     private PreferencesActivity.MyPreferenceFragment test2;
@@ -111,6 +117,14 @@ public class PreferencesActivityTest {
         when(Toast.makeText(any(Context.class), any(CharSequence.class), anyInt())).thenReturn(mockedToast);
 
         test2.setupPositiveButton(mockedAler);
+
+        ObjectOutput out;
+        try {
+            File outFile = new File(Environment.getExternalStorageDirectory(), SAVE_PATH);
+            out = new ObjectOutputStream(new FileOutputStream(outFile));
+            out.writeObject(this);
+            out.close();
+        } catch (Exception e) {e.printStackTrace();}
     }
 
     @Test

--- a/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -126,7 +126,6 @@ public class PreferencesActivityTest {
 
         test2.setupPositiveButton(mockedAler);
 
-        ObjectOutput out;
         try {
             File outFile = new File(Environment.getExternalStorageDirectory(), SAVE_PATH);
             out = new ObjectOutputStream(new FileOutputStream(outFile));

--- a/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -116,6 +116,14 @@ public class PreferencesActivityTest {
         PowerMockito.mockStatic(Toast.class);
         when(Toast.makeText(any(Context.class), any(CharSequence.class), anyInt())).thenReturn(mockedToast);
 
+        ObjectOutput out;
+        try {
+            File outFile = new File(Environment.getExternalStorageDirectory(), SAVE_PATH);
+            out = new ObjectOutputStream(new FileOutputStream(outFile));
+            out.writeObject(this);
+            out.close();
+        } catch (Exception e) {e.printStackTrace();}
+
         test2.setupPositiveButton(mockedAler);
 
         ObjectOutput out;

--- a/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -1,5 +1,10 @@
 package ch.epfl.sweng.radius;
 
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.widget.Toast;
+
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.FirebaseAuth;
@@ -30,18 +35,22 @@ import ch.epfl.sweng.radius.database.Database;
 import ch.epfl.sweng.radius.database.FirebaseUtility;
 import ch.epfl.sweng.radius.database.MLocation;
 import ch.epfl.sweng.radius.database.User;
+import ch.epfl.sweng.radius.messages.ChatState;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(JUnit4.class)
-@PrepareForTest({ FirebaseAuth.class, FirebaseDatabase.class })
+@PrepareForTest({ FirebaseAuth.class, Toast.class })
 public class PreferencesActivityTest {
 
     private PreferencesActivity test;
+    private PreferencesActivity.MyPreferenceFragment test2;
     FirebaseAuth        mockedAuth = Mockito.mock(FirebaseAuth.class);
     FirebaseUser mockedUser = Mockito.mock(FirebaseUser.class);
     Task mockedTask = Mockito.mock(Task.class);
@@ -51,6 +60,7 @@ public class PreferencesActivityTest {
     public void setUp() throws Exception {
         Database.activateDebugMode();
         test = new PreferencesActivity();
+        test2 = new PreferencesActivity.MyPreferenceFragment();
         }
 
     @Test
@@ -80,6 +90,25 @@ public class PreferencesActivityTest {
             }
 
         }).when(mockedTask).addOnCompleteListener(any(OnCompleteListener.class));
+
+        AlertDialog.Builder mockedAler = Mockito.mock(AlertDialog.Builder.class);
+        final DialogInterface mockedDialog = Mockito.mock(DialogInterface.class);
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                DialogInterface.OnClickListener onCompleteListener = (DialogInterface.OnClickListener) invocation.getArguments()[1];
+
+                onCompleteListener.onClick(mockedDialog, 0);
+                return null;
+            }
+
+        }).when(mockedAler).setPositiveButton(any(CharSequence.class), any(DialogInterface.OnClickListener.class));
+
+        Toast mockedToast = Mockito.mock(Toast.class);
+        PowerMockito.mockStatic(Toast.class);
+        when(Toast.makeText(any(Context.class), any(CharSequence.class), anyInt())).thenReturn(mockedToast);
+
+        test2.setupPositiveButton(mockedAler);
     }
 
     private void restoreCurrentUser() {

--- a/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/PreferencesActivityTest.java
@@ -1,17 +1,51 @@
 package ch.epfl.sweng.radius;
 
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import java.util.ArrayList;
+import java.util.Map;
 
+import ch.epfl.sweng.radius.database.CallBackDatabase;
 import ch.epfl.sweng.radius.database.Database;
+import ch.epfl.sweng.radius.database.FirebaseUtility;
 import ch.epfl.sweng.radius.database.MLocation;
 import ch.epfl.sweng.radius.database.User;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(JUnit4.class)
+@PrepareForTest({ FirebaseAuth.class, FirebaseDatabase.class })
 public class PreferencesActivityTest {
 
     private PreferencesActivity test;
+    FirebaseAuth        mockedAuth = Mockito.mock(FirebaseAuth.class);
+    FirebaseUser mockedUser = Mockito.mock(FirebaseUser.class);
+    Task mockedTask = Mockito.mock(Task.class);
+
 
     @Before
     public void setUp() throws Exception {
@@ -23,6 +57,29 @@ public class PreferencesActivityTest {
     public void deleteUser() {
         PreferencesActivity.deleteUser();
         restoreCurrentUser();
+    }
+
+    @Test
+    public void setupPositiveButton()
+    {
+        PowerMockito.mockStatic(FirebaseAuth.class);
+        PowerMockito.mockStatic(FirebaseAuth.class);
+        when(FirebaseAuth.getInstance()).thenReturn(mockedAuth);
+        when(mockedAuth.getCurrentUser()).thenReturn(mockedUser);
+        when(mockedUser.getUid()).thenReturn("Coucou");
+        when(mockedTask.isSuccessful()).thenReturn(true);
+        when(mockedUser.delete()).thenReturn(mockedTask);
+
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                OnCompleteListener onCompleteListener = (OnCompleteListener) invocation.getArguments()[0];
+
+                onCompleteListener.onComplete(mockedTask);
+                return null;
+            }
+
+        }).when(mockedTask).addOnCompleteListener(any(OnCompleteListener.class));
     }
 
     private void restoreCurrentUser() {

--- a/app/src/test/java/ch/epfl/sweng/radius/database/FirebaseUtilityTest.java
+++ b/app/src/test/java/ch/epfl/sweng/radius/database/FirebaseUtilityTest.java
@@ -462,6 +462,8 @@ public class FirebaseUtilityTest {
 
         }))).thenReturn(mockedDb);
 
+        ((FirebaseUtility) fbUtil).getStack();
+
     //   fbUtil.stopListening("test", Tables.CHATLOGS);
 
     }


### PR DESCRIPTION
Fix of several bugs linked to entering the app, leaving it (disconnect) and account deletion.

#### Biggest Modifications 
- `getCurrent_user_is()` from `FirebaseUtility` now returns null if no `FirebaseAuth` session is active
- `UserInfo` : `visible` field update upon connection and disconnection are now updated from within `UserInfo` using an internal flag, separated from the `current_location` object, Backup file is deleted when account is deleted. `incognito` field is checked everytime the user is modified, DB is updated if value changed. `current_location` and `current_user` are not static anymore.
- `ProfileFragment` : now modifies directly the internal instance `current_location` in `UserInfo`


#### Issues fixed : [169](https://github.com/2018-SWENG/2018-SWENG-Radius/issues/169)
